### PR TITLE
允许docker用户重设更新代码的网址REPO_URL

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ ENV LANG="C.UTF-8" \
     NASTOOL_CONFIG="/config/config.yaml" \
     NASTOOL_AUTO_UPDATE=1 \
     PS1="\u@\h:\w \$ " \
+    REPO_URL="https://github.com/jxxghp/nas-tools.git" \
     PUID=0 \
     PGID=0 \
     UMASK=000
@@ -31,7 +32,7 @@ RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
     && echo 'fs.inotify.max_user_watches=524288' >> /etc/sysctl.conf \
     && echo 'fs.inotify.max_user_instances=524288' >> /etc/sysctl.conf \
     && git config --global pull.ff only \
-    && git clone -b master https://github.com/jxxghp/nas-tools . \
+    && git clone -b master ${REPO_URL} . \
     && pip config set global.index-url https://mirrors.bfsu.edu.cn/pypi/web/simple \
     && pip install pip -U \
     && pip install -r requirements.txt \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,6 +6,7 @@ if [ -n $NASTOOL_AUTO_UPDATE ]; then
         sha256sum requirements.txt > /tmp/requirements.txt.sha256sum
     fi
     echo "更新程序..."
+    git remote set-url origin ${REPO_URL} &>/dev/null
     git pull
     if [ $? -eq 0 ]; then
         echo "更新成功..."

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -37,6 +37,8 @@ docker run -d \
     jxxghp/nas-tools
 ```
 
+如果你访问github的网络不太好，可以考虑在创建容器时增加设置一个环境变量`-e REPO_URL="https://ghproxy.com/https://github.com/jxxghp/nas-tools.git" \`。
+
 **docker-compose**
 
 新建`docker-compose.yml`文件如下，并以命令`docker-compose up -d`启动。
@@ -55,6 +57,7 @@ services:
       - PUID=0    # 想切换为哪个用户来运行程序，该用户的uid，详见下方说明
       - PGID=0    # 想切换为哪个用户来运行程序，该用户的gid，详见下方说明
       - UMASK=000 # 掩码权限，默认000，可以考虑设置为022
+      #-REPO_URL="https://ghproxy.com/https://github.com/jxxghp/nas-tools.git"  # 当你访问github网络很差时，可以考虑解释本行注释
     restart: always
     network_mode: bridge
     hostname: nas-tools


### PR DESCRIPTION
如果你访问github的网络不太好，可以考虑在创建容器时增加设置一个环境变量`-e REPO_URL="https://ghproxy.com/https://github.com/jxxghp/nas-tools.git" \`。
