### PR TITLE
新增 群晖翻墙教程

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Docker：https://hub.docker.com/repository/docker/jxxghp/nas-tools
 
 群晖套件：https://github.com/jxxghp/nas-tools/releases/tag/Synology
 
+群晖翻墙：https://github.com/bobo0810/Summary/blob/main/doc/trojan_go.md
+
 TG交流：https://t.me/nastool_chat
 
 ## 功能：


### PR DESCRIPTION
Host方式不稳定，直接翻墙一劳永逸~
教程以群晖为例，支持NAS、Linux等客户端翻墙。