### PR TITLE
资源搜索耗时优化：优化大量数据下查询返回和重复查询耗时

### DIFF
--- a/pt/searcher.py
+++ b/pt/searcher.py
@@ -130,8 +130,7 @@ class Searcher:
                 delete_all_search_torrents()
                 # 插入数据库
                 save_media_list = Torrent.get_torrents_group_item(media_list)
-                for save_media_item in save_media_list:
-                    insert_search_results(save_media_item)
+                insert_search_results(save_media_list)
                 self.message.send_channel_msg(channel=in_from,
                                               title=media_info.get_title_vote_string(),
                                               text="%s 共检索到 %s 个有效资源" % (media_info.title, len(save_media_list)),

--- a/rmt/metainfo.py
+++ b/rmt/metainfo.py
@@ -10,6 +10,7 @@ from rmt.category import Category
 from utils.functions import is_chinese
 from utils.tokens import Tokens
 from utils.types import MediaType
+from functools import lru_cache
 
 
 class MetaInfo(object):
@@ -782,7 +783,10 @@ class MetaInfo(object):
         self.description = description
 
     # 获取消息媒体图片
-    def get_fanart_image(self, search_type, tmdbid, default=None):
+    # 增加cache，优化资源检索时性能
+    @staticmethod
+    @lru_cache(maxsize=256)
+    def get_fanart_image(search_type, tmdbid, default=None, proxies=None):
         if not search_type:
             return ""
         if tmdbid:
@@ -791,7 +795,7 @@ class MetaInfo(object):
             else:
                 image_url = FANART_TV_API_URL % tmdbid
             try:
-                ret = requests.get(image_url, timeout=10, proxies=self.config.get_proxies())
+                ret = requests.get(image_url, timeout=10, proxies=proxies)
                 if ret:
                     moviethumbs = ret.json().get('moviethumb')
                     if moviethumbs:

--- a/utils/db_helper.py
+++ b/utils/db_helper.py
@@ -189,6 +189,20 @@ class DBHelper:
             cursor.close()
         return True
 
+    def excute_many(self, sql, data_list):
+        if not sql or not data_list:
+            return False
+        cursor = self.__connection.cursor()
+        try:
+            cursor.executemany(sql, data_list)
+            self.__connection.commit()
+        except Exception as e:
+            log.error("【DB】执行SQL出错：%s， %s, %s" % (sql, data_list, str(e)))
+            return False
+        finally:
+            cursor.close()
+        return True
+
     def select(self, sql):
         if not sql:
             return False
@@ -220,3 +234,13 @@ def update_by_sql(sql):
     :return: 执行状态
     """
     return DBHelper().excute(sql)
+
+
+def update_by_sql_batch(sql, data_list):
+    """
+    执行更新或删除
+    :param sql: 批量更新SQL语句
+    :param data_list: 数据列表
+    :return: 执行状态
+    """
+    return DBHelper().excute_many(sql, data_list)

--- a/utils/sqls.py
+++ b/utils/sqls.py
@@ -1,19 +1,13 @@
 import os.path
 import time
 
-from utils.db_helper import update_by_sql, select_by_sql
+from utils.db_helper import update_by_sql, select_by_sql, update_by_sql_batch
 from utils.functions import str_filesize, xstr, str_sql
 from utils.types import MediaType
 
 
 # 将返回信息插入数据库
-def insert_search_results(media_item):
-    if media_item.type == MediaType.TV:
-        mtype = "TV"
-    elif media_item.type == MediaType.MOVIE:
-        mtype = "MOV"
-    else:
-        mtype = "ANI"
+def insert_search_results(media_items):
     sql = "INSERT INTO SEARCH_TORRENTS(" \
           "TORRENT_NAME," \
           "ENCLOSURE," \
@@ -33,27 +27,40 @@ def insert_search_results(media_item):
           "PEERS," \
           "SITE," \
           "SITE_ORDER) VALUES (" \
-          "'%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s')" % (
-              str_sql(media_item.org_string),
-              media_item.enclosure,
-              str_sql(media_item.description),
-              mtype,
-              media_item.title,
-              xstr(media_item.year),
-              media_item.get_season_string(),
-              media_item.get_episode_string(),
-              media_item.get_season_episode_string(),
-              media_item.vote_average,
-              media_item.get_backdrop_path(),
-              media_item.get_resource_type_string(),
-              media_item.res_order,
-              str_filesize(int(media_item.size)),
-              media_item.seeders,
-              media_item.peers,
-              media_item.site,
-              media_item.site_order
-          )
-    return update_by_sql(sql)
+          " ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    data_list = []
+    for media_item in media_items:
+        if media_item.type == MediaType.TV:
+            mtype = "TV"
+        elif media_item.type == MediaType.MOVIE:
+            mtype = "MOV"
+        else:
+            mtype = "ANI"
+
+        data_list.append(
+            (
+                str_sql(media_item.org_string),
+                media_item.enclosure,
+                str_sql(media_item.description),
+                mtype,
+                media_item.title,
+                xstr(media_item.year),
+                media_item.get_season_string(),
+                media_item.get_episode_string(),
+                media_item.get_season_episode_string(),
+                media_item.vote_average,
+                media_item.get_backdrop_path(),
+                media_item.get_resource_type_string(),
+                media_item.res_order,
+                str_filesize(int(media_item.size)),
+                media_item.seeders,
+                media_item.peers,
+                media_item.site,
+                media_item.site_order
+            )
+        )
+
+    return update_by_sql_batch(sql, data_list)
 
 
 # 根据ID从数据库中查询检索结果的一条记录

--- a/web/backend/search_torrents.py
+++ b/web/backend/search_torrents.py
@@ -31,5 +31,4 @@ def search_medias_for_web(content):
         media_list = Torrent.get_torrents_group_item(media_list)
         log.info("【WEB】分组择优后剩余 %s 个有效资源" % len(media_list))
         # 插入数据库
-        for media_item in media_list:
-            insert_search_results(media_item)
+        insert_search_results(media_list)


### PR DESCRIPTION
1.增加fanart查询缓存，优化资源搜索时重复查询导致耗时
2.搜索结果sql存储修改为批量插入，解决单次搜索大量结果时循环插入耗时过高问题

优化前：
<img width="1387" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/14013384/167244550-20b3d6e3-ef9c-4ccf-83f2-1827165601ff.png">

优化后：
<img width="1396" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/14013384/167244569-5992954d-a636-4d17-99d3-5ea93dd09b7d.png">

检索蝙蝠侠，结果数量200+，初次耗时2.4min->1.6min，再次检索43.68s->1.53s