### PR TITLE
* 资源搜索耗时优化：优化并发查询及其缓存限制

### DIFF
--- a/utils/meta_helper.py
+++ b/utils/meta_helper.py
@@ -21,8 +21,12 @@ class MetaHelper(object):
         self.__meta_path = os.path.join(os.path.dirname(config.get_config_path()), 'meta.dat')
         self.__meta_data = self.__load_meta_data(self.__meta_path)
 
-    def get_meta_data(self):
+    def __get_meta_data(self):
         return self.__meta_data
+
+    def get_meta_data_by_key(self, key):
+        with lock:
+            return self.__get_meta_data().get(key)
 
     @staticmethod
     def __load_meta_data(path):
@@ -34,13 +38,13 @@ class MetaHelper(object):
             return {}
 
     def update_meta_data(self, meta_data):
-        for key, item in meta_data.items():
-            if not self.__meta_data.get(key):
-                self.__meta_data[key] = item
+        with lock:
+            for key, item in meta_data.items():
+                if not self.__meta_data.get(key):
+                    self.__meta_data[key] = item
 
     def save_meta_data(self):
-        try:
-            lock.acquire()
+        with lock:
             meta_data = self.__load_meta_data(self.__meta_path)
             save_flag = False
             for key, item in self.__meta_data.items():
@@ -51,5 +55,3 @@ class MetaHelper(object):
                 return
             with open(self.__meta_path, 'wb') as f:
                 pickle.dump(meta_data, f, pickle.HIGHEST_PROTOCOL)
-        finally:
-            lock.release()


### PR DESCRIPTION
1.优化fanart数据不存在时缓存miss的问题，限定缓存max 256
2.缩小tmdb cache lock作用域，让其在cache miss时可以并发查询

优化后查询返回282资源，耗时40s
<img width="1380" alt="image" src="https://user-images.githubusercontent.com/14013384/167301041-26fbfa5b-ef2d-48fe-8d56-c4f31359cc21.png">
<img width="490" alt="image" src="https://user-images.githubusercontent.com/14013384/167301076-42435a60-1e45-46b6-978a-e07718196546.png">
