### PR TITLE
fix(rmt): get_no_exists_medias bug fix

### DIFF
--- a/rmt/filetransfer.py
+++ b/rmt/filetransfer.py
@@ -808,7 +808,11 @@ class FileTransfer:
                 files = get_dir_files_by_ext(dest_path, RMT_MEDIAEXT)
                 for file in files:
                     file_meta_info = MetaInfo(os.path.basename(file))
-                    if not file_meta_info.get_episode_list():
+                    if not file_meta_info.get_season_list() or file_meta_info.get_episode_list():
+                        continue
+                    if not file_meta_info.cn_name == meta_info.cn_name:
+                        continue
+                    if season not in file_meta_info.get_season_list():
                         continue
                     exists_episodes = list(set(exists_episodes).union(set(file_meta_info.get_episode_list())))
             return list(set(total_episodes).difference(set(exists_episodes)))


### PR DESCRIPTION
遍历获取exists_episodes时从tv path根目录下获取，没有判断过滤对应的剧名和season，导致未存在的集也返回了。