### PR TITLE
分离运环境和nas-tools自身程序，让构建更快捷。

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -1,18 +1,11 @@
-name: Build Image
+name: Build Base Image
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - master
-    paths:
-      - requirements.txt
-      - docker/Dockerfile
-      - docker/entrypoint.sh
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build Docker Image
+    name: Build Base Image
     steps:
       - 
         name: Checkout
@@ -38,7 +31,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: docker/Dockerfile
+          file: docker/Dockerfile.base
           platforms: |
             linux/386
             linux/amd64
@@ -46,4 +39,4 @@ jobs:
             linux/arm/v7
           push: true
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/nas-tools:latest
+            ${{ secrets.DOCKER_USERNAME }}/nas-tools-base-image:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM jxxghp/nas-tools-base-image
 ENV LANG="C.UTF-8" \
     TZ="Asia/Shanghai" \
     NASTOOL_CONFIG="/config/config.yaml" \
@@ -10,32 +10,13 @@ ENV LANG="C.UTF-8" \
     UMASK=000 \
     WORKDIR="/nas-tools"
 WORKDIR ${WORKDIR}
-RUN apk add --no-cache \
-       git \
-       gcc \
-       musl-dev \
-       python3-dev \
-       py3-pip \
-       libxml2-dev \
-       libxslt-dev \
-       tzdata \
-       su-exec \
-    && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
-    && echo "${TZ}" > /etc/timezone \
-    && ln -sf /usr/bin/python3 /usr/bin/python \
-    && python_ver=$(python3 -V | awk '{print $2}') \
+RUN python_ver=$(python3 -V | awk '{print $2}') \
     && echo "${WORKDIR}/" > /usr/lib/python${python_ver%.*}/site-packages/nas-tools.pth \
     && echo 'fs.inotify.max_user_watches=524288' >> /etc/sysctl.conf \
     && echo 'fs.inotify.max_user_instances=524288' >> /etc/sysctl.conf \
     && git config --global pull.ff only \
     && git clone -b master ${REPO_URL} --depth=1 ${WORKDIR} \
     && git config --global --add safe.directory ${WORKDIR} \
-    && pip install --upgrade pip setuptools wheel \
-    && pip install -r requirements.txt \
-    && mkdir -p /var/log/supervisor \
-    && rm -rf \
-       /tmp/* \
-       /root/.cache \
-       /var/cache/apk/*
+    && mkdir -p /var/log/supervisors
 VOLUME ["/config"]
 ENTRYPOINT ["/nas-tools/docker/entrypoint.sh"]

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,17 @@
+FROM alpine
+RUN apk add --no-cache \
+       git \
+       gcc \
+       musl-dev \
+       python3-dev \
+       py3-pip \
+       libxml2-dev \
+       libxslt-dev \
+       tzdata \
+       su-exec \
+    && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo "${TZ}" > /etc/timezone \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && pip install --upgrade pip setuptools wheel \
+    && pip install -r https://raw.githubusercontent.com/devome/nas-tools/master/requirements.txt \
+    && rm -rf /tmp/* /root/.cache /var/cache/apk/*


### PR DESCRIPTION
如下图所示，需要手动构建基础镜像nas-tools-base-image，每次需要构建时，按下图1 2 3点击即可。

![image](https://user-images.githubusercontent.com/93664269/171329620-77cc9cb3-bd32-4f62-9c41-4806813087cf.png)
