### PR TITLE
fix: 修复db_pool释放时死锁问题

### DIFF
--- a/utils/db_pool.py
+++ b/utils/db_pool.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from queue import Queue
 import sqlite3
-import log
 import threading
+from queue import Empty, Queue
+
+import log
 
 
 class SQLit3PoolConnection:
@@ -45,9 +46,10 @@ class DBPool(object):
         print("release Pool..")
         self.__lock.acquire()
         while self.__free_conns and not self.__free_conns.empty():
-            con = self.get()
-            con.close()
-            if self.__free_conns.empty():
+            try:
+                con = self.__free_conns.get()
+                con.close()
+            except Empty:
                 break
         self.__free_conns = None
         self.__lock.release()


### PR DESCRIPTION
修复 SIGINT 退出时 db_pool `releases()` 死锁