### PR TITLE
fix: 修复名称识别时年份后跟随 GBR 的边界情况

### DIFF
--- a/rmt/meta/metavideo.py
+++ b/rmt/meta/metavideo.py
@@ -54,8 +54,8 @@ class MetaVideo(MetaBase):
         title = re.sub(r'%s' % self._name_no_begin_re, "", title, count=1)
         # 把xxxx-xxxx年份换成前一个年份，常出现在季集上
         title = re.sub(r'([\s.]+)(\d{4})-(\d{4})', r'\1\2', title)
-        # 把大小去掉
-        title = re.sub(r'[0-9.]+\s*[MGT]i?B', "", title, flags=re.IGNORECASE)
+        # 把大小去掉；排除年份后跟随 GBR 的边界情况
+        title = re.sub(r'[0-9.]+\s*[MGT]i?B(?!R)', "", title, flags=re.IGNORECASE)
         # 把年月日去掉
         title = re.sub(r'\d{4}[\s._-]\d{1,2}[\s._-]\d{1,2}', "", title)
         # 拆分tokens


### PR DESCRIPTION
在去除文件名的 `GB` 时确保该文本不为 `GBR`，以避免 `GBR` 跟随年份的情况造成误判。

考虑如下命名：
```
The Woodsman and the Rain 2011 GBR Blu-ray 1080p AVC DTS-HD MA 5.1-DIY@TTG
Martial Club 1981 GBR BluRay 1080p x265 10bit MiniFHD-XPcl@PTer
Twelve.Monkeys.1995.GBR.4K.REMASTERED.BluRay.1080p.x264.DTS
```

目前会被识别为：
```
The Woodsman and the Rain R Blu
Martial Club R
Twelve MonkeysR
```