### PR TITLE
tmdb没有中文名称由豆瓣替换

### DIFF
--- a/rmt/douban.py
+++ b/rmt/douban.py
@@ -1,0 +1,44 @@
+import re
+import sys
+import requests
+import urllib.parse
+
+class Douban():
+	# 电影查询api以及头文件
+	def __init__(self,tmdb_name):
+		self.headers = {
+			'User-Agent' : 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36',
+			'Host' : 'movie.douban.com',
+		}
+		self.search_url = 'https://movie.douban.com/j/subject_suggest?q={}'
+		self.name = tmdb_name
+    # 名称检查
+	def name_check(self):
+		en_re = re.compile(r'[A-Za-z]', re.S)
+		res = re.findall(en_re, self.name)
+		if res == []:
+			return False
+		else:
+			return True
+	# 外部调用
+	def run(self):
+		name = self.name
+		# requests获取搜索结果
+		try:
+			res = requests.get(self.search_url.format(urllib.parse.quote(name)), headers=self.headers)
+			results = res.json()
+		except:
+			pass
+		if len(results) == 0:
+			return name
+		else:
+			#使用第一个搜索结果
+			douban_name = results[0].get('title')
+			season_re = re.compile('第*\S*季')
+			season_name = re.findall(season_re, douban_name)
+			if season_name == []:
+				return douban_name
+			else:
+				douban_name = douban_name.replace(season_name[0],"")
+				douban_name = douban_name.rstrip()
+				return douban_name

--- a/rmt/media.py
+++ b/rmt/media.py
@@ -19,6 +19,7 @@ from utils.cache_manager import cacheman
 import difflib
 from rmt.constants import *
 
+from rmt.douban import Douban
 
 class Media:
     # TheMovieDB
@@ -468,6 +469,10 @@ class Media:
                     tmdb_info['media_type'] = MediaType.TV
             if tmdb_info:
                 tmdb_info['genre_ids'] = self.__get_genre_ids_from_detail(tmdb_info.get('genres'))
+        #如果tmdb没有中文名称由豆瓣替换
+        tmdb_name =str(tmdb_info.get("name"))
+        if Douban(tmdb_name).name_check():
+            tmdb_info['name'] = Douban(tmdb_name).run()
         return tmdb_info
 
     def get_tmdb_infos(self, title, year=None, mtype: MediaType = None, num=6):


### PR DESCRIPTION
部分剧集tmdb的中文名被删除，例如终极名单，爱死机，怪奇物语等。

识别后文件夹名，文件名都没有问题
![image](https://user-images.githubusercontent.com/16237201/184209824-1bc07ea7-a6f7-41ae-badc-17b84ec5e339.png)
![image](https://user-images.githubusercontent.com/16237201/184172473-49b97cc8-2801-43a2-a215-a3c58094716a.png)

但是生成元数据tvshow.nfo在电视剧包含大量集数的情况下会失效，每一集都会get_tmdb_info()导致短时间大量访问豆瓣，后面的集数就无法获得豆瓣的中文名称

第一集正常

![image](https://user-images.githubusercontent.com/16237201/184172819-8a5ef772-250e-455d-9b88-06ff2025596c.png)

到转移第五集时豆瓣无返回，失效

![image](https://user-images.githubusercontent.com/16237201/184172906-d13020be-aaa5-4713-9ceb-f633d39049a5.png)

最后tvshow.nfo里还是tmdb的名称

自学的写代码，写得烂，见笑了


