### PR TITLE
修复构建基础镜像时安装cryptography依赖库失败

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -13,6 +13,9 @@ RUN apk add --no-cache \
        curl \
        bash \
        fuse \
+       libressl-dev --repository https://pkgs.alpinelinux.org/package/edge/community/ \
+       libffi-dev --repository https://pkgs.alpinelinux.org/package/edge/main \
+       cargo --repository https://pkgs.alpinelinux.org/package/edge/community/ \
     && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone \
     && ln -sf /usr/bin/python3 /usr/bin/python \


### PR DESCRIPTION
https://github.com/jxxghp/nas-tools/actions/runs/2889194112

https://github.com/Shurelol/nas-tools/actions