### PR TITLE
优化基础镜像体积

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -13,13 +13,14 @@ RUN apk add --no-cache \
        curl \
        bash \
        fuse \
-       libressl-dev --repository https://pkgs.alpinelinux.org/package/edge/community/ \
+       openssl-dev --repository https://pkgs.alpinelinux.org/package/edge/main \
        libffi-dev --repository https://pkgs.alpinelinux.org/package/edge/main \
-       cargo --repository https://pkgs.alpinelinux.org/package/edge/community/ \
+       cargo --repository https://pkgs.alpinelinux.org/package/edge/community \
     && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && curl https://rclone.org/install.sh | bash \
     && pip install --upgrade pip setuptools wheel \
     && pip install -r https://raw.githubusercontent.com/jxxghp/nas-tools/master/requirements.txt \
+    && apk del openssl-dev libffi-dev cargo \
     && rm -rf /tmp/* /root/.cache /var/cache/apk/*


### PR DESCRIPTION
https://hub.docker.com/r/shurelol/nas-tools-base-image
https://hub.docker.com/r/shurelol/nas-tools
镜像大小减下来了，简单运行了下好像没什么问题