### PR TITLE
增加网络测试 | 优化群晖和windows流，并发布至telegram频道

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - master
     paths:
       - version.py
-      - .github/workflows/build.yml
+      - .github/workflows/build-test.yml
 
 jobs:
   create-release:
@@ -29,38 +29,28 @@ jobs:
         body: ${{ github.event.commits[0].message }}
         draft: false
         prerelease: false
-    - name: output release_id
-      run: echo "${{ steps.create_release.outputs.id }}" > release_id.txt
-    - name: save release_id
+    - name: output release_informations
+      run: |
+        echo "${{ steps.create_release.outputs.id }}" > release_id.txt
+        echo "${{ env.app_version }}" > app_version.txt
+    - name: save release_informations
       uses: actions/upload-artifact@v3
       with:
-        name: release_id
-        path: release_id.txt
-    - name: output app_version
-      run: echo "${{ env.app_version }}" > app_version.txt
-    - name: save app_version
-      uses: actions/upload-artifact@v3
-      with:
-        name: app_version
-        path: app_version.txt
+        name: release_informations
+        path: |
+          release_id.txt
+          app_version.txt
 
   synology-build:
     runs-on: ubuntu-latest
     needs: create-release
     steps:
-    - name: download release_id and app_version
+    - name: download release_informations
       uses: actions/download-artifact@v3
-    - name: get release_id
-      id: get_release_id
-      shell: bash
-      run: |
-        value=`cat release_id/release_id.txt`
-        echo "release_id=$value" >> $GITHUB_ENV
     - name: get app_version
-      id: get_app_version
       shell: bash
       run: |
-        value=`cat app_version/app_version.txt`
+        value=`cat release_informations/app_version.txt`
         echo "app_version=$value" >> $GITHUB_ENV
     - name: Build the synology spk
       run: |
@@ -88,28 +78,16 @@ jobs:
         cd ..
         mkdir spks
         mv spk6/nastool_dsm_6.x.spk spk7/nastool_dsm_7.x.spk spks/
-    - name: Upload release asset
-      id: upload-release-asset
-      uses: dwenegar/upload-release-assets@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: upload synology files
+      uses: actions/upload-artifact@v3
       with:
-        release_id: ${{ env.release_id }}
-        assets_path: /home/runner/work/nas-tools/nas-tools/nas-tools/spks/
+        name: synology
+        path: /home/runner/work/nas-tools/nas-tools/nas-tools/spks/
 
   windows-build:
     runs-on: windows-latest
     needs: create-release
     steps:
-    - name: download release_id and app_version
-      uses: actions/download-artifact@v3
-    - name: get release_id
-      id: get_release_id
-      shell: bash
-      run: |
-        value=`cat release_id/release_id.txt`
-        echo "release_id=$value" >> $GITHUB_ENV
-        echo "${{ env.release_id }}"
     - name: init Python 3.10.6
       uses: actions/setup-python@v4
       with:
@@ -136,24 +114,59 @@ jobs:
         xcopy .\web c:\hostedtoolcache\windows\python\3.10.6\x64\lib\site-packages\web\ /e &&
         cd windows &&
         pyinstaller nas-tools.spec /
+    - name: upload windows file
+      uses: actions/upload-artifact@v3
+      with:
+        name: windows
+        path: D:/a/nas-tools/nas-tools/nas-tools/windows/dist/nas-tools.exe
+
+  Send-message:
+    runs-on: ubuntu-latest
+    needs: [synology-build, windows-build]
+    steps:
+    - name: download release_informations
+      uses: actions/download-artifact@v3
+    - name: get release_informations
+      shell: bash
+      run: |
+        value=`cat release_informations/release_id.txt`
+        echo "release_id=$value" >> $GITHUB_ENV
+        value=`cat release_informations/app_version.txt`
+        echo "app_version=$value" >> $GITHUB_ENV
     - name: Upload release asset
-      id: upload-release-asset
       uses: dwenegar/upload-release-assets@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         release_id: ${{ env.release_id }}
-        assets_path: D:/a/nas-tools/nas-tools/nas-tools/windows/dist/nas-tools.exe
-
-  Send-message:
-    runs-on: ubuntu-latest
-    needs: [synology-build,windows-build]
-    steps:
-    - name: Send telegram message
+        assets_path: |
+            /home/runner/work/nas-tools/nas-tools/synology/
+            /home/runner/work/nas-tools/nas-tools/windows/
+    - name: Send telegram message (release informations)
       uses: appleboy/telegram-action@master
       with:
         to: ${{ secrets.TELEGRAM_TO }}
         token: ${{ secrets.TELEGRAM_TOKEN }}
+        format: markdown
         message: |
-          ${{ github.event.commits[0].message }}
-          Repository: ${{ github.repository }}
+            *${{ env.app_version }}*
+
+            ${{ github.event.commits[0].message }}
+    - name: Send telegram message synology 1
+      uses: appleboy/telegram-action@master
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        document: /home/runner/work/nas-tools/nas-tools/synology/nastool_dsm_6.x.spk
+    - name: Send telegram message synology 2
+      uses: appleboy/telegram-action@master
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        document: /home/runner/work/nas-tools/nas-tools/synology/nastool_dsm_7.x.spk
+    - name: Send telegram message windows
+      uses: appleboy/telegram-action@master
+      with:
+        to: ${{ secrets.TELEGRAM_TO }}
+        token: ${{ secrets.TELEGRAM_TOKEN }}
+        document: /home/runner/work/nas-tools/nas-tools/windows/nas-tools.exe

--- a/web/action.py
+++ b/web/action.py
@@ -95,6 +95,7 @@ class WebAction:
             "delete_downloader": self.__delete_downloader,
             "name_test": self.__name_test,
             "rule_test": self.__rule_test,
+            "net_test": self.__net_test,
             "add_filtergroup": self.__add_filtergroup,
             "set_default_filtergroup": self.__set_default_filtergroup,
             "del_filtergroup": self.__del_filtergroup,
@@ -1494,6 +1495,19 @@ class WebAction:
             "name": rule_name if rule_name else "未设置默认规则",
             "order": 100 - res_order if res_order else 0
         }
+
+    @staticmethod
+    def __net_test(data):
+        target = data
+        if target == "image.tmdb.org":
+            target = target + "/t/p/w500/wwemzKWzjKYJFfCeiB57q3r4Bcm.png"
+        target = "https://" + target
+        if not RequestUtils().get_res(target):
+            return {"res": False}
+        elif RequestUtils().get_res(target).ok:
+            return {"res": True}
+        else:
+            return {"res": False}
 
     @staticmethod
     def __get_site_activity(data):

--- a/web/main.py
+++ b/web/main.py
@@ -950,6 +950,18 @@ def create_flask_app(config):
         scheduler_cfg_list.append(
             {'name': '过滤规则测试', 'time': '', 'state': 'OFF', 'id': 'ruletest', 'svg': svg, 'color': 'yellow'})
 
+        # 网络连接性测试
+        svg = '''
+        <svg t="1660720525544" class="icon" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="1559" width="16" height="16">
+        <path d="M646 1024H100A100 100 0 0 1 0 924V258a100 100 0 0 1 100-100h546a100 100 0 0 1 100 100v31a40 40 0 1 1-80 0v-31a20 20 0 0 0-20-20H100a20 20 0 0 0-20 20v666a20 20 0 0 0 20 20h546a20 20 0 0 0 20-20V713a40 40 0 0 1 80 0v211a100 100 0 0 1-100 100z" fill="#ffffff" p-id="1560"></path>
+        <path d="M924 866H806a40 40 0 0 1 0-80h118a20 20 0 0 0 20-20V100a20 20 0 0 0-20-20H378a20 20 0 0 0-20 20v8a40 40 0 0 1-80 0v-8A100 100 0 0 1 378 0h546a100 100 0 0 1 100 100v666a100 100 0 0 1-100 100z" fill="#ffffff" p-id="1561"></path>
+        <path d="M469 887a40 40 0 0 1-27-10L152 618a40 40 0 0 1 1-60l290-248a40 40 0 0 1 66 30v128a367 367 0 0 0 241-128l94-111a40 40 0 0 1 70 35l-26 109a430 430 0 0 1-379 332v142a40 40 0 0 1-40 40zM240 589l189 169v-91a40 40 0 0 1 40-40c144 0 269-85 323-214a447 447 0 0 1-323 137 40 40 0 0 1-40-40v-83z" fill="#ffffff" p-id="1562"></path>
+        </svg>
+        '''
+        targets = ["api.themoviedb.org", "image.tmdb.org", "www.themoviedb.org", "images.weserv.nl", "webservice.fanart.tv", "google.ca"]
+        scheduler_cfg_list.append(
+            {'name': '网络连接性测试', 'time': '', 'state': 'OFF', 'id': 'nettest', 'svg': svg, 'color': 'red', "targets": targets})
+
         # 备份
         svg = '''
         <svg t="1660720525544" class="icon" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="1559" width="16" height="16">

--- a/web/templates/service.html
+++ b/web/templates/service.html
@@ -143,6 +143,44 @@
     </div>
   </div>
 </div>
+<div class="modal modal-blur fade" id="modal-nettest" tabindex="-1" role="dialog" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="card border-top-0">
+        <div class="card-header">
+          <h5 class="modal-title">网络连接性测试</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="card-body border-bottom py-3">
+          <div class="table-responsive">
+            <table class="table table-vcenter card-table">
+              <thead>
+                <tr>
+                  <th>测试对象</th>
+                  <th>可连接</th>
+                  <!-- 隐藏span储存测试列表 -->
+                  <span id="test_targets" style="display:none">{{ SchedulerTasks[-2].targets }}<span>
+                </tr>
+              </thead>
+              <tbody>
+                {% for target in SchedulerTasks[-2].targets %}
+                <tr>
+                  <td><span>{{ target }}</span></td>
+                  <td id="{{ target }}"></td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-link me-auto" data-bs-dismiss="modal">取消</button>
+        <button id="nettest_btn" class="btn btn-primary">测试</button>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="modal modal-blur fade" id="modal-backup" tabindex="-1" role="dialog" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
   <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
     <div class="modal-content">
@@ -177,6 +215,8 @@
       $('#modal-nametest').modal('show');
     } else if (id == "ruletest") {
       $('#modal-ruletest').modal('show');
+    } else if (id == "nettest") {
+      $('#modal-nettest').modal('show');
     } else if (id == "blacklist"){
       show_confirm_modal("清理缓存后，已转移过的文件允许重新转移（包括识别错误的文件），是否确认？", function(){
         hide_confirm_modal();
@@ -210,6 +250,11 @@
   // 规则测试
   $("#ruletest_btn").click(function () {
     rule_test();
+  });
+
+  // 网络测试
+  $("#nettest_btn").click(function () {
+    net_test();
   });
 
   // 备份
@@ -330,6 +375,41 @@
           $("#testrule_result").append('<span class="badge bg-red me-1 mb-1">'+ret.text+'</span>');
         }
       }
+    });
+  }
+  //网络连接性测试
+  function net_test(){
+    //从隐藏的span获取测试列表（字符串类型）
+    var targets = $("#test_targets").text();
+    targets = targets.replace(/'/g,"");
+    targets = targets.replace(/\[/g,"");
+    targets = targets.replace(/\]/g,"");
+    targets = targets.split(",");
+    $("#nettest_btn").text("测试中");
+    $("#nettest_btn").attr("disabled", true);
+    var currentIndex = 0;
+    net_test_ajax(targets,currentIndex);
+  }
+
+  //递归轮询测试结果
+  function net_test_ajax(targets,currentIndex){
+    stopindex = targets.length
+    if(currentIndex >= targets.length){
+      $("#nettest_btn").text("测试");
+      $("#nettest_btn").attr("disabled", false);
+      return;
+    }
+    var target = '';
+    target = targets[currentIndex];
+    target = target.replace(/\s*/g,"");
+    ajax_post("net_test", target, function (ret) {
+      if(ret.res){
+        document.getElementById(target).innerHTML = '<span class="badge badge-outline text-green me-1 mb-1">是</span>';
+      }else{
+        document.getElementById(target).innerHTML = '<span class="badge badge-outline text-red me-1 mb-1">否</span>';
+      }
+      currentIndex++;
+      net_test_ajax(targets,currentIndex)
     });
   }
 


### PR DESCRIPTION
1、增加网络测试大多数使用环境非本地，测试网络不方便，需要更多的测试对象，增加main.py中的targets列表即可（图标svg麻烦调整下）
![image](https://user-images.githubusercontent.com/16237201/185762227-42502d70-d1a7-4d59-9b4d-cca429bc8584.png)
![image](https://user-images.githubusercontent.com/16237201/185762237-1e2ba1a4-df6e-4efe-b11d-e7eb0cb63cb5.png)
2、优化群晖和windows流，并发布至telegram频道，（secrets.TELEGRAM_TO请填NASTOOL小秘书频道id，commit的summary
请避免使用版本号以免重复，commit的description如需• 请用• 用md的*在电报中无法识别）效果如下
![image](https://user-images.githubusercontent.com/16237201/185769067-35a7e16f-7923-407a-9d87-ac526f576685.png)
标记部分为发送时默认信息，目前除了用自定义覆盖无法不发送，只能手动删除。