### PR TITLE
更新EMBY同级目录匹配

### DIFF
--- a/app/mediaserver/server/emby.py
+++ b/app/mediaserver/server/emby.py
@@ -344,6 +344,9 @@ class Emby(IMediaServer):
             max_path_len = 0
             equal_path_num = 0
             for folder in library.get("SubFolders"):
+                list = re.split(pattern='/+|\\\\+', string=folder.get("Path"))
+                if item.get("category") != list[-1]:
+                    continue
                 try:
                     path_len = len(os.path.commonpath([item.get("target_path"), folder.get("Path")]))
                     if path_len >= max_path_len:


### PR DESCRIPTION
添加匹配同级路径先判断最后一级目录，如果不匹配最后一级目录会刷新错误的目录ID。比如媒体库添加了F:/阿里云盘/电视剧/，F:/阿里云盘/电影/，F:/阿里云盘/动漫/等这是三个媒体库，转移最后一级目录是动漫，才匹配到电视剧的媒体库就返回成功了
![image](https://user-images.githubusercontent.com/23020770/187141414-d6e20300-8ae9-4039-bf40-64a65e1f5185.png)
