### PR TITLE
feature 记录手动识别的信息，解决追剧时识别失败导致无法硬链接

### DIFF
--- a/app/media/media.py
+++ b/app/media/media.py
@@ -735,6 +735,7 @@ class Media:
                         continue
                     media_key = "[%s]%s-%s-%s" % (
                         meta_info.type.value, meta_info.get_name(), meta_info.year, meta_info.begin_season)
+                    file_media_info = ""
                     if not self.meta.get_meta_data_by_key(media_key):
                         # 调用TMDB API
                         file_media_info = self.__search_tmdb(file_media_name=meta_info.get_name(),
@@ -770,6 +771,27 @@ class Media:
                         else:
                             # 标记为未找到避免再次查询
                             self.meta.update_meta_data({media_key: {'id': 0}})
+                    # 未找到，遍历 rename.txt寻找可能存在的tmdbid
+                    if not file_media_info:
+                        temp_name = meta_info.get_name()  # 待匹配名称
+                        try:
+                            with open("rename.txt", "r") as f:
+                                line = f.readline()  # 调用文件的 readline()方法
+                                while line:
+                                    if temp_name in line:
+                                        log.info("【】在rename.txt中查找到tmdbid")
+                                        tmdbid = line.split(",")[1].replace('\n', '')
+                                        file_media_info = Media().get_tmdb_info(meta_info.type, title=temp_name,
+                                                                                tmdbid=int(tmdbid))
+                                        self.meta.delete_meta_data(media_key)  # 短时间内直接update似乎无效，先删除该key缓存
+                                        self.meta.update_meta_data({media_key: file_media_info})
+                                        print(self.meta.get_meta_data_by_key(media_key))
+                                        break
+                                    line = f.readline()
+                                f.close()
+                        except Exception as e:
+                            print(str(e))
+                            log.error("【】rename.txt文件打开/写入失败")
                     # 查找中文名
                     cache_title = self.meta.get_cache_title(key=media_key)
                     if cache_title and chinese and not StringUtils.is_chinese(

--- a/web/action.py
+++ b/web/action.py
@@ -511,6 +511,20 @@ class WebAction:
         season = data.get("season")
         episode_format = data.get("episode_format")
         min_filesize = data.get("min_filesize")
+        # 把手工识别的影视及输入的tmdbid追加到rename.txt
+        file_path = data.get("path")
+        file_name = os.path.basename(file_path)
+        meta_info = MetaInfo(title=file_name)
+        media_name = meta_info.get_name()
+        if media_name and tmdbid:
+            try:
+                with open("rename.txt", 'a') as f:
+                    f.write(','.join((media_name, tmdbid)) + '\n')
+                    log.info("【】手动识别%s,%s写入到rename.txt" % (media_name, tmdbid))
+                    f.close()
+            except Exception as e:
+                print(str(e))
+                log.error("【】rename.txt文件打开/写入失败")
         if mtype == "TV":
             media_type = MediaType.TV
         elif mtype == "MOV":
@@ -558,6 +572,20 @@ class WebAction:
         episode_details = data.get("episode_details")
         episode_offset = data.get("episode_offset")
         min_filesize = data.get("min_filesize")
+        # 把自定义识别的影视及输入的tmdbid追加到rename.txt
+        file_path = inpath
+        file_name = os.path.basename(inpath if inpath[-1] != "/" else inpath[:-1])
+        meta_info = MetaInfo(title=file_name)
+        media_name = meta_info.get_name()
+        if media_name and tmdbid:
+            try:
+                with open("rename.txt", 'a') as f:
+                    f.write(','.join((media_name, tmdbid)) + '\n')
+                    log.info("【】自定义识别%s,%s写入到rename.txt" % (media_name, tmdbid))
+                    f.close()
+            except Exception as e:
+                print(str(e))
+                log.error("【】rename.txt文件打开/写入失败")
         if mtype == "TV":
             media_type = MediaType.TV
         elif mtype == "MOV":


### PR DESCRIPTION
## 问题描述
假设订阅了一部连续剧且识别失败，手动识别后可进行硬链接；但是当该剧有新一集后，rss订阅把新一集下载，此时还是会识别失败，从而没有进行硬链接，导致Emby媒体库里就没有该剧集了。影响追剧效果。
## 解决思路
使用手动识别或自定义识别时，记录剧集的名字和用户输入的tmdbid，保存到文本中。在下一次识别失败时，在文本中搜索该剧名字，若存在匹配的，则获取其tmdbid，然后进行识别，即可保证识别成功。
## 存在缺陷
因为目前仅存储（ 经过解析媒体名称 MetaInfo(title=file_name).get_name()后的名字，tmdbid），所以可能会存在这样一种情况，有识别失败的电影A和电视剧B，经过解析媒体的名称是相同的，但手动识别时候tmdbid确实不同的，导致以后出现错误识别。但是这个概率其实很小了。
## 其他
经过用户输入的tmdbid的可信度是很高的，可以把大家识别失败的，及其对应的tmdbid号都收集一下。以后识别失败可以尝试用这个去匹配。
【效果图】(https://img1.imgtp.com/2022/09/04/OuWHj6b5.png)