### PR TITLE
增加剧集RSS订阅支持

### DIFF
--- a/app/db/db_helper.py
+++ b/app/db/db_helper.py
@@ -101,6 +101,7 @@ class DBHelper:
                                    DESC    TEXT,
                                    TOTAL    INTEGER,
                                    LACK    INTEGER,
+                                   RSS_URL TEXT,
                                    STATE    TEXT);''')
             cursor.execute('''CREATE INDEX IF NOT EXISTS INDX_RSS_TVS_NAME ON RSS_TVS(NAME);''')
             # 电视剧订阅剧集明细

--- a/app/db/sql_helper.py
+++ b/app/db/sql_helper.py
@@ -601,19 +601,19 @@ class SqlHelper:
         """
         if rssid:
             sql = "SELECT NAME,YEAR,SEASON,TMDBID,IMAGE,DESC,TOTAL,LACK,STATE" \
-                  ",((CAST(TOTAL AS FLOAT)-CAST(LACK AS FLOAT))/CAST(TOTAL AS FLOAT))*100,ID" \
+                  ",((CAST(TOTAL AS FLOAT)-CAST(LACK AS FLOAT))/CAST(TOTAL AS FLOAT))*100,ID,RSS_URL" \
                   " FROM RSS_TVS" \
                   " WHERE ID = ?"
             return DBHelper().select_by_sql(sql, (rssid,))
         else:
             if not state:
                 sql = "SELECT NAME,YEAR,SEASON,TMDBID,IMAGE,DESC,TOTAL,LACK,STATE" \
-                      ",((CAST(TOTAL AS FLOAT)-CAST(LACK AS FLOAT))/CAST(TOTAL AS FLOAT))*100,ID" \
+                      ",((CAST(TOTAL AS FLOAT)-CAST(LACK AS FLOAT))/CAST(TOTAL AS FLOAT))*100,ID,RSS_URL" \
                       " FROM RSS_TVS"
                 return DBHelper().select_by_sql(sql)
             else:
                 sql = "SELECT NAME,YEAR,SEASON,TMDBID,IMAGE,DESC,TOTAL,LACK,STATE" \
-                      ",((CAST(TOTAL AS FLOAT)-CAST(LACK AS FLOAT))/CAST(TOTAL AS FLOAT))*100,ID" \
+                      ",((CAST(TOTAL AS FLOAT)-CAST(LACK AS FLOAT))/CAST(TOTAL AS FLOAT))*100,ID,RSS_URL" \
                       " FROM RSS_TVS WHERE STATE = ?"
                 return DBHelper().select_by_sql(sql, (state,))
 
@@ -686,6 +686,7 @@ class SqlHelper:
                       rss_pix=None,
                       rss_team=None,
                       rss_rule=None,
+                      rss_url=None,
                       match=False
                       ):
         """
@@ -702,7 +703,7 @@ class SqlHelper:
         if SqlHelper.is_exists_rss_tv(media_info.title, media_info.year, season_str):
             return True
         # 插入订阅数据
-        sql = "INSERT INTO RSS_TVS(NAME,YEAR,SEASON,TMDBID,IMAGE,DESC,TOTAL,LACK,STATE) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        sql = "INSERT INTO RSS_TVS(NAME,YEAR,SEASON,TMDBID,IMAGE,DESC,TOTAL,LACK,STATE,RSS_URL) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,?)"
         desc = "#".join(["|".join(sites or []),
                          "|".join(search_sites or []),
                          "Y" if over_edition else "N",
@@ -718,7 +719,8 @@ class SqlHelper:
                                               desc,
                                               total,
                                               lack,
-                                              state))
+                                              state,
+                                              rss_url))
 
     @staticmethod
     def update_rss_tv_lack(title=None, year=None, season=None, rssid=None, lack_episodes: list = None):

--- a/app/media/media.py
+++ b/app/media/media.py
@@ -571,7 +571,6 @@ class Media:
                 tv['media_type'] = MediaType.TV
                 ret_infos.append(tv)
         return ret_infos
-
     def get_media_info(self, title, subtitle=None, mtype=None, strict=None, cache=True, chinese=True):
         """
         只有名称信息，判别是电影还是电视剧并搜刮TMDB信息，用于种子名称识别

--- a/app/rss.py
+++ b/app/rss.py
@@ -216,7 +216,7 @@ class Rss:
                                                                              source=library_no_exists,
                                                                              title=media_info.tmdb_id)
                                     log.info("【RSS】%s 缺失季集：%s" % (media_info.get_title_string(),
-                                                                  rss_no_exists.get(media_info.tmdb_id)))
+                                                                      rss_no_exists.get(media_info.tmdb_id)))
                         # 返回对象
                         media_info.set_torrent_info(res_order=res_order,
                                                     download_volume_factor=download_volume_factor,
@@ -254,7 +254,7 @@ class Rss:
                                 if item.rssid:
                                     log.info(
                                         "【RSS】电视剧 %s %s 订阅完成，删除订阅..." % (item.get_title_string(),
-                                                                         item.get_season_string()))
+                                                                                    item.get_season_string()))
                                     SqlHelper.delete_rss_tv(rssid=item.rssid)
                                     # 发送订阅完成的消息
                                     self.message.send_rss_finished_message(item)
@@ -368,6 +368,7 @@ class Rss:
             year = tv[1] or ""
             season = tv[2]
             tmdbid = tv[3]
+            rss_url = tv[11]
             total = int(tv[6]) if str(tv[6]).isdigit() else 0
             # 跳过模糊匹配的
             if not season or not tmdbid:
@@ -417,8 +418,7 @@ class Rss:
                                                      source=library_no_exists,
                                                      title=media_info.tmdb_id)
                 log.info("【RSS】%s 缺失季集：%s" % (media_info.get_title_string(),
-                                              no_exists.get(media_info.tmdb_id)))
-
+                                                  no_exists.get(media_info.tmdb_id)))
             # 开始检索
             search_result, no_exists, search_count, download_count = self.searcher.search_one_media(
                 media_info=media_info,
@@ -500,7 +500,8 @@ class Rss:
                 if total_episode and (name != media_info.title or total != total_episode):
                     # 新的缺失集数
                     lack_episode = total_episode - (total - lack)
-                    log.info(f"【RSS】检测到TMDB信息变化，更新电视剧订阅 {name} 为 {media_info.title}，总集数为：{total_episode}")
+                    log.info(
+                        f"【RSS】检测到TMDB信息变化，更新电视剧订阅 {name} 为 {media_info.title}，总集数为：{total_episode}")
                     # 更新订阅信息
                     SqlHelper.update_rss_tv_tmdb(rid=rid,
                                                  tmdbid=media_info.tmdb_id,
@@ -804,12 +805,12 @@ class Rss:
                 return None, None, total_episodes, res_order, upload_volume_factor, download_volume_factor, season
             else:
                 log.info("【RSS】%s 识别为 %s%s 匹配订阅成功" % (media_info.org_string,
-                                                      media_info.get_title_string(),
-                                                      media_info.get_season_episode_string()))
+                                                               media_info.get_title_string(),
+                                                               media_info.get_season_episode_string()))
                 log.info("【RSS】种子描述：%s" % media_info.subtitle)
                 return rssid, over_edition, total_episodes, res_order, upload_volume_factor, download_volume_factor, season
         else:
             log.info("【RSS】%s 识别为 %s%s 不在订阅范围" % (media_info.org_string,
-                                                  media_info.get_title_string(),
-                                                  media_info.get_season_episode_string()))
+                                                           media_info.get_title_string(),
+                                                           media_info.get_season_episode_string()))
             return None, None, total_episodes, res_order, upload_volume_factor, download_volume_factor, season

--- a/app/searcher.py
+++ b/app/searcher.py
@@ -38,6 +38,7 @@ class Searcher:
                       key_word,
                       filter_args: dict,
                       match_type,
+                      rss_url=None,
                       match_media=None,
                       in_from: SearchType = None):
         """
@@ -47,8 +48,15 @@ class Searcher:
         :param match_type: 匹配模式：0-识别并模糊匹配；1-识别并精确匹配；2-不识别匹配
         :param match_media: 区配的媒体信息
         :param in_from: 搜索渠道
+        :param rss_url: rss订阅链接
         :return: 命中的资源媒体信息列表
         """
+        if rss_url:
+            from app.rss import Rss
+            return Rss().search_by_rss(key_word=key_word,
+                                       filter_args=filter_args,
+                                       media_info=match_media,
+                                       rss_url=rss_url)
         if not key_word:
             return []
         if not self.indexer:
@@ -62,6 +70,7 @@ class Searcher:
     def search_one_media(self, media_info,
                          in_from: SearchType,
                          no_exists: dict,
+                         rss_url=None,
                          sites: list = None,
                          filters: dict = None):
         """
@@ -114,6 +123,7 @@ class Searcher:
         media_list = self.search_medias(key_word=search_title,
                                         filter_args=filter_args,
                                         match_type=1,
+                                        rss_url=rss_url,
                                         match_media=media_info,
                                         in_from=in_from)
         # 使用名称重新搜索

--- a/web/action.py
+++ b/web/action.py
@@ -1314,7 +1314,7 @@ class WebAction:
                          "year": rss[0][1],
                          "season": rss[0][2],
                          "tmdbid": rss[0][3],
-                         "rss_url": rss[0][4],
+                         "rss_url": rss[0][11],
                          "r_sites": r_sites,
                          "s_sites": s_sites,
                          "over_edition": over_edition,

--- a/web/action.py
+++ b/web/action.py
@@ -913,6 +913,7 @@ class WebAction:
         rss_pix = data.get("rss_pix")
         rss_team = data.get("rss_team")
         rss_rule = data.get("rss_rule")
+        rss_url = data.get("rss_url")
         rssid = data.get("rssid")
         if name and mtype:
             if mtype in ['nm', 'hm', 'dbom', 'dbhm', 'dbnm', 'MOV']:
@@ -933,6 +934,7 @@ class WebAction:
                                                   rss_pix=rss_pix,
                                                   rss_team=rss_team,
                                                   rss_rule=rss_rule,
+                                                  rss_url=rss_url,
                                                   rssid=rssid)
         return {"code": code, "msg": msg, "page": page, "name": name}
 
@@ -1312,6 +1314,7 @@ class WebAction:
                          "year": rss[0][1],
                          "season": rss[0][2],
                          "tmdbid": rss[0][3],
+                         "rss_url": rss[0][4],
                          "r_sites": r_sites,
                          "s_sites": s_sites,
                          "over_edition": over_edition,

--- a/web/backend/subscribe.py
+++ b/web/backend/subscribe.py
@@ -16,6 +16,7 @@ def add_rss_subscribe(mtype, name, year,
                       rss_pix=None,
                       rss_team=None,
                       rss_rule=None,
+                      rss_url=None,
                       state="D",
                       rssid=None):
     """
@@ -36,6 +37,7 @@ def add_rss_subscribe(mtype, name, year,
     :param rss_rule: 关键字过滤
     :param state: 添加订阅时的状态
     :param rssid: 修改订阅时传入
+    :param rss_url: RSS订阅地址
     :return: 错误码：0代表成功，错误信息
     """
     if not name:
@@ -117,6 +119,7 @@ def add_rss_subscribe(mtype, name, year,
                                     rss_pix=rss_pix,
                                     rss_team=rss_team,
                                     rss_rule=rss_rule,
+                                    rss_url=rss_url,
                                     state=state,
                                     match=match)
         else:
@@ -164,6 +167,7 @@ def add_rss_subscribe(mtype, name, year,
                                     rss_pix=rss_pix,
                                     rss_team=rss_team,
                                     rss_rule=rss_rule,
+                                    rss_url=rss_url,
                                     match=match)
 
     return 0, "添加订阅成功", media_info

--- a/web/templates/rss/tv_rss.html
+++ b/web/templates/rss/tv_rss.html
@@ -186,6 +186,16 @@
               </div>
             </div>
           </div>
+          <div class="row rss_sites_container" id="rss_sites_div">
+            <div class="mb-3">
+              <label class="form-label">RSS地址</label>
+              <div class="form-selectgroup">
+                <label class="form-selectgroup-item">
+                    <input type="text" value="" id="rss_url" class="form-control" placeholder="RSS订阅地址">
+                </label>
+              </div>
+            </div>
+          </div>
           <div class="row rss_sites_container" id="rss_search_sites_div">
             <div class="mb-3">
               <label class="form-label">搜索站点</label>
@@ -226,6 +236,7 @@
     var rss_restype = $("#rss_restype").val();
     var rss_pix = $("#rss_pix").val();
     var rss_team = $("#rss_team").val();
+    var rss_url = $("#rss_url").val();
     var rss_rule = $("#rss_rule").val();
     var over_edition = $("#over_edition").prop("checked");
     if (!name) {
@@ -294,6 +305,7 @@
                  "rss_restype": rss_restype,
                  "rss_pix": rss_pix,
                  "rss_team": rss_team,
+                 "rss_url": rss_url,
                  "rss_rule": rss_rule,
                  "over_edition": over_edition,
                  "rssid": rssid,
@@ -414,6 +426,7 @@
         $("#rss_restype").val(ret.detail.filter.restype);
         $("#rss_pix").val(ret.detail.filter.pix);
         $("#rss_team").val(ret.detail.filter.team);
+        $("#rss_url").val(ret.detail.rss_url);
         $("#rss_rule").val(ret.detail.filter.rule);
         $("#rss_sites_div").find("input[type=checkbox]").each(function(){
           if(ret.detail.r_sites.length==0 || ret.detail.r_sites.includes($(this).val())){


### PR DESCRIPTION
实现 #935 的功能
1. 在表RSS_TVS中添加RSS_URL字段
2. 在search_medias方法中实现rss_url的订阅逻辑
3. 如果有传入的rss_url，直接调用rss_url解析种子列表，跳过通过索引工具查询

为了避免 #1056 引起的问题，会以查询出的media_info的tmdb_id为准