### PR TITLE
增加自定义识别屏蔽词

### DIFF
--- a/app/media/meta/metainfo.py
+++ b/app/media/meta/metainfo.py
@@ -4,7 +4,7 @@ import re
 from app.media.meta.metaanime import MetaAnime
 from app.media.meta.metavideo import MetaVideo
 from app.utils.types import MediaType
-from config import RMT_MEDIAEXT
+from config import RMT_MEDIAEXT, Config
 
 
 def MetaInfo(title, subtitle=None, mtype=None):
@@ -15,6 +15,13 @@ def MetaInfo(title, subtitle=None, mtype=None):
     :param mtype: 指定识别类型，为空则自动识别类型
     :return: MetaAnime、MetaVideo
     """
+    config = Config()
+    ignored_words = []
+    ignored_words_info = config.get_config('laboratory').get("ignored_words")
+    if ignored_words_info:
+        ignored_words = ignored_words_info.split("|")
+        for ignored_word in ignored_words:
+            title = title.replace(ignored_word, "")
     if os.path.splitext(title)[-1] in RMT_MEDIAEXT:
         fileflag = True
     else:

--- a/app/media/meta/metainfo.py
+++ b/app/media/meta/metainfo.py
@@ -16,12 +16,9 @@ def MetaInfo(title, subtitle=None, mtype=None):
     :return: MetaAnime、MetaVideo
     """
     config = Config()
-    ignored_words = []
-    ignored_words_info = config.get_config('laboratory').get("ignored_words")
-    if ignored_words_info:
-        ignored_words = ignored_words_info.split("|")
-        for ignored_word in ignored_words:
-            title = title.replace(ignored_word, "")
+    ignored_words = config.get_config('laboratory').get("ignored_words")
+    if ignored_words:
+        title = re.sub(r"" + ignored_words, "", title)
     if os.path.splitext(title)[-1] in RMT_MEDIAEXT:
         fileflag = True
     else:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -427,3 +427,5 @@ laboratory:
   use_douban_titles: true
   # 【精确搜索使用英文名称】：开启后对于精确搜索场景（远程搜索、订阅搜索等）将会使用英文名检索站点资源以提升匹配度，但对有些站点资源标题全是中文的则需要关闭，否则匹配不到
   search_en_title: true
+  # 【自定义识别屏蔽词】
+  ignored_words: 

--- a/web/main.py
+++ b/web/main.py
@@ -1162,7 +1162,10 @@ def create_flask_app(config):
         proxy = config.get_config('app').get("proxies", {}).get("http")
         if proxy:
             proxy = proxy.replace("http://", "")
-        return render_template("setting/basic.html", Config=config.get_config(), Proxy=proxy)
+        ignored_words = config.get_config('laboratory').get("ignored_words")
+        if ignored_words:
+            ignored_words =ignored_words.replace("|", "\n")
+        return render_template("setting/basic.html", Config=config.get_config(), Proxy=proxy, Ignored_Words=ignored_words)
 
     # 目录同步页面
     @App.route('/directorysync', methods=['POST', 'GET'])

--- a/web/templates/setting/basic.html
+++ b/web/templates/setting/basic.html
@@ -403,6 +403,11 @@
           </div>
           <div class="card-footer">
             <div class="row align-items-center">
+              <div class="col-auto">
+                <a href="javascript:void(0)" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#modal-ignored_words">
+                  自定义识别屏蔽词设置
+                </a>
+              </div>
               <div class="col"></div>
               <div class="col-auto">
                 <a id="laboratory_btn" href="javascript:save_basic_config('laboratory')" class="btn btn-primary">
@@ -716,6 +721,27 @@
     </div>
   </div>
 </div>
+<div class="modal modal-blur fade" id="modal-ignored_words" tabindex="-1" role="dialog" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content border-0">
+      <div class="card">
+        <div class="card-header">
+          <h5 class="modal-title">自定义识别屏蔽词</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="card-body">
+          <textarea class="form-control" id="ignored_words" rows="4" placeholder="增加屏蔽词请换行">{{ Ignored_Words }}</textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-link me-auto" data-bs-dismiss="modal">取消</button>
+        <a id="scraper_save_btn" href="javascript:save_ignored_words_config()" class="btn btn-primary">
+          保存
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
 <script type="text/javascript">
   // 保存基础设置
   function save_basic_config(type){
@@ -746,10 +772,20 @@
     });
   }
 
-  //保存搜刮配置
+  // 保存搜刮配置
   function save_scraper_config(){
     save_basic_config('modal-scraper');
     $("#modal-scraper").modal("hide");
+  }
+  // 保存自定义识别屏蔽词配置
+  function save_ignored_words_config(){
+    var params = {};
+    var ignored_words = $("#ignored_words").val().replace(/\n/g,"|");
+    console.log(ignored_words)
+    params['laboratory.ignored_words'] = ignored_words
+    ajax_post("update_config", params, function (ret) {
+    });
+    $("#modal-ignored_words").modal("hide");
   }
 
 </script>

--- a/web/templates/setting/basic.html
+++ b/web/templates/setting/basic.html
@@ -781,7 +781,6 @@
   function save_ignored_words_config(){
     var params = {};
     var ignored_words = $("#ignored_words").val().replace(/\n/g,"|");
-    console.log(ignored_words)
     params['laboratory.ignored_words'] = ignored_words
     ajax_post("update_config", params, function (ret) {
     });


### PR DESCRIPTION
识别时，会先从名称中去掉自定义识别屏蔽词后再开始识别

特别是bt站奇奇怪怪的命名，去掉一些干扰项后会增加识别的正确率

![image](https://user-images.githubusercontent.com/16237201/190921265-6f9a6b75-6e3a-4a01-87c6-4e21748808d3.png)
![image](https://user-images.githubusercontent.com/16237201/190921205-874c9eb0-0280-4a2e-b68f-048eae40b0cf.png)
![image](https://user-images.githubusercontent.com/16237201/190921212-0d78946b-33ff-4490-bfa3-24452be88800.png)
