### PR TITLE
fix：生成rss链接时，项目标题格式选取其他项（如副标题）导致制作组/字幕组识别失败

### DIFF
--- a/app/media/meta/release_groups.py
+++ b/app/media/meta/release_groups.py
@@ -109,7 +109,7 @@ sites = [rg_1pt,
 release_groups = '|'
 for site in sites:
     for release_group in site:
-        release_groups = release_groups + "(?<=[-@[￡])" + release_group + "(?=[@.\s\]])" + "|"
+        release_groups = release_groups + "(?<=[-@[￡])" + release_group + "(?=[@.\s\][])" + "|"
 release_groups = re.compile(r"" + release_groups[1:-1], re.I)
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16237201/192421174-e3c61fa5-4cba-426b-b410-bf907023b470.png)
#### 例如在生成rss时，项目标题格式选取副标题
- title会从
  Big Brother US S24 1080p AMZN WEB-DL DDP2.0 H.264-NTb
- 变成
  Big Brother US S24 1080p AMZN WEB-DL DDP2.0 H.264-NTb[老大哥(美版) 第二十四季]
- 导致制作组/字幕组识别失败