### PR TITLE
feat: add telegram proxy to fetch message without webhook

### DIFF
--- a/app/message/channel/telegram.py
+++ b/app/message/channel/telegram.py
@@ -1,5 +1,7 @@
-from threading import Lock
+from threading import Event, Lock
 from urllib.parse import urlencode
+from app.helper.thread_helper import ThreadHelper
+import requests
 
 import log
 from config import Config
@@ -19,6 +21,7 @@ class Telegram(IMessageChannel):
     __telegram_user_ids = None
     __domain = None
     __config = None
+    __message_proxy_event = None
 
     def __init__(self):
         self.init_config()
@@ -41,11 +44,21 @@ class Telegram(IMessageChannel):
             if self.__telegram_user_ids:
                 self.__telegram_user_ids = self.__telegram_user_ids.split(",")
             if self.__telegram_token \
-                    and self.__telegram_chat_id \
-                    and message.get('telegram', {}).get('webhook') \
-                    and self.__domain:
-                self.__webhook_url = "%stelegram" % self.__domain
-                self.__set_bot_webhook()
+                and self.__telegram_chat_id \
+                and self.__domain:
+                    if message.get('telegram', {}).get('webhook'):
+                        self.__webhook_url = "%stelegram" % self.__domain
+                        self.__set_bot_webhook()
+                        if self.__message_proxy_event:
+                            self.__message_proxy_event.set()
+                            self.__message_proxy_event = None
+                    else: 
+                        self.__del_bot_webhook()
+                        if not self.__message_proxy_event:
+                            event = Event()
+                            self.__message_proxy_event = event
+                            ThreadHelper().start_thread(self.__start_telegram_message_proxy, [event])
+ 
 
     def get_status(self):
         """
@@ -221,3 +234,45 @@ class Telegram(IMessageChannel):
         获取Telegram配置文件中的User Ids，即允许使用telegram机器人的user_id列表
         """
         return self.__telegram_user_ids or []
+    
+
+    def __start_telegram_message_proxy(self, event: Event):
+        log.info("TelegramBot message proxy start")
+
+        long_poll_timeout = 5
+        def consume_messages(_config, _offset, _sc_url, _ds_url):
+            try:
+                values = {"timeout": long_poll_timeout, "offset": _offset}
+                res = RequestUtils(proxies=_config.get_proxies()).get_res(_sc_url + urlencode(values))
+                if res and res.json():
+                    for msg in res.json().get("result", []):
+                        log.info("TelegramBot message: %s" % msg)
+                        local_res = requests.post(_ds_url, json=msg, timeout=1)
+                        log.info("TelegramBot message: %s processed, response is: %s" % (msg, local_res.text))
+                        _offset = msg["update_id"] + 1
+            except Exception as e:
+                log.error("something wrong with telegram message proxy: %s" % e)
+            return _offset
+        
+        offset = 0
+        while True:
+            # read config from config.yaml directly to make config.yaml changes aware 
+            config = Config()
+
+            message = config.get_config("message")
+            channel = message.get("msg_channel")
+            telegram_token = message.get('telegram', {}).get('telegram_token')
+            web_port = config.get_config("app").get("web_port")
+            sc_url = "https://api.telegram.org/bot%s/getUpdates?" % telegram_token
+            ds_url = "http://localhost:%s/telegram" % web_port
+            telegram_webhook = message.get('telegram', {}).get('webhook')
+            if not channel == "telegram" or not telegram_token or telegram_webhook:
+                log.info("TelegramBot message proxy stop")
+                break
+            
+            i = 0
+            while i < 20  and not event.is_set():
+                offset = consume_messages(config, offset, sc_url, ds_url)
+                i = i + 1
+
+            


### PR DESCRIPTION
跟 issue #1024 相关
使用`long-poll` api  https://core.telegram.org/bots/api#getting-updates 实现无需配置webhook接收telegram的消息

基本逻辑：
1. 每次poll 5s，若无新消息，连接会阻塞直到超时后返回空列表，若有新消息会立即返回
2. 收到消息之后按顺序去请求本地api http://localhost:<port>/telegram
3. 每执行20次重新读取配置文件检查是否发生channel切换从而可以及时退出
4. 每次执行通过Event变量检测webhook开关是否关闭从而及时退出 (避免未及时退出导致多个线程同时执行，telegram可能会报conflic 错误)

只在个人的truenas的docker上测试过

