### PR TITLE
确保从telegram拉取的消息只会消费一次

### DIFF
--- a/app/message/channel/telegram.py
+++ b/app/message/channel/telegram.py
@@ -248,10 +248,11 @@ class Telegram(IMessageChannel):
                 res = RequestUtils(proxies=_config.get_proxies()).get_res(_sc_url + urlencode(values))
                 if res and res.json():
                     for msg in res.json().get("result", []):
+                        # 无论本地是否成功，先更新offset，即消息最多成功消费一次
+                        _offset = msg["update_id"] + 1
                         log.info("TelegramBot 接收到消息: %s" % msg)
                         local_res = requests.post(_ds_url, json=msg, timeout=10)
                         log.debug("TelegramBot message: %s processed, response is: %s" % (msg, local_res.text))
-                        _offset = msg["update_id"] + 1
             except Exception as e:
                 log.error("TelegramBot 消息接收出现错误: %s" % e)
             return _offset


### PR DESCRIPTION
从telegram拉取的消息如果由于各种原因消费失败会导致重复轮询，而且会导致后续的消息无法消费，所以更合理的策略应该是
1. 无论是否消费成功，offset都更新确保下次不会重新拉取消息
2. （或者）设置最大的重试次数

