### PR TITLE
fixed #1553

### DIFF
--- a/app/downloader/client/qbittorrent.py
+++ b/app/downloader/client/qbittorrent.py
@@ -132,8 +132,11 @@ class Qbittorrent(IDownloadClient):
             path = torrent.get('save_path')
             if not path:
                 continue
+            content_path = torrent.get('content_path')
+            if not content_path:
+                continue
             true_path = self.get_replace_path(path)
-            trans_tasks.append({'path': os.path.join(true_path, torrent.get('name')), 'id': torrent.get('hash')})
+            trans_tasks.append({'path': os.path.join(true_path, content_path[len(path):]), 'id': torrent.get('hash')})
         return trans_tasks
 
     def get_remove_torrents(self, seeding_time, tag):


### PR DESCRIPTION
AttrDict({'added_on': 1665518765, 'amount_left': 0, 'auto_tmm': True, 'availability': -1, 'category': '', 'completed': 314729309, 'completion_on': 1665556911, 'content_path': '/downloads/Ghost.in.the.Shell.Stand.Alone.Complex.Solid.State.Society.2006.720p.BrRip.x265.HEVCBay.com.mkv', 'dl_limit': -1, 'dlspeed': 0, 'download_path': '', 'downloaded': 314739963, 'downloaded_session': 162767709, 'eta': 8640000, 'f_l_piece_prio': False, 'force_start': True, 'hash': '931c5cf02610cc61b07d9094a1aa03e9e29c47d7', 'infohash_v1': '931c5cf02610cc61b07d9094a1aa03e9e29c47d7', 'infohash_v2': '', 'last_activity': 1665596358, 'magnet_uri': 'magnet:?xt=urn:btih:931c5cf02610cc61b07d9094a1aa03e9e29c47d7', 'max_ratio': -1, 'max_seeding_time': -1, 'name': 'Ghost.in.the.Shell.Stand.Alone.Complex.Solid.State.Society.2006.720p.BrRip.x265.HEVCBay', 'num_complete': 4, 'num_incomplete': 1, 'num_leechs': 0, 'num_seeds': 0, 'priority': 0, 'progress': 1, 'ratio': 0.8068629022492451, 'ratio_limit': -2, 'save_path': '/downloads', 'seeding_time': 40403, 'seeding_time_limit': -2, 'seen_complete': 1665596364, 'seq_dl': False, 'size': 314729309, 'state': 'forcedUP', 'super_seeding': False, 'tags': '已整理', 'time_active': 53611, 'total_size': 314729309, 'tracker': '', 'trackers_count': 152, 'up_limit': -1, 'uploaded': 253952000, 'uploaded_session': 253952000, 'upspeed': 0})

以这个种子为例，名字为 Ghost.in.the.Shell.Stand.Alone.Complex.Solid.State.Society.2006.720p.BrRip.x265.HEVCBay

而实际存放的路径在 content_path 字段中

故此 PR 在 content_path 中截出来了实际的路径中的名字以解决问题