### PR TITLE
迁移下载目录配置至列表

### DIFF
--- a/app/downloader/client/client.py
+++ b/app/downloader/client/client.py
@@ -146,12 +146,12 @@ class IDownloadClient(metaclass=ABCMeta):
         """
         if not true_path:
             return ""
-        downloaddir = Config().get_config('downloaddir') or {}
-        for path, attr in downloaddir.items():
-            if not path or not attr.get("path"):
+        downloaddir = Config().get_config('downloaddir') or []
+        for attr in downloaddir:
+            if not attr["save_path"] or not attr["container_path"]:
                 continue
-            if os.path.normpath(path) == os.path.normpath(true_path):
-                return attr.get("path")
+            if os.path.normpath(attr["save_path"]) == os.path.normpath(true_path):
+                return attr["container_path"]
         return true_path
 
     @abstractmethod

--- a/config.py
+++ b/config.py
@@ -244,6 +244,15 @@ class Config(object):
                                 "season_thumb": True}
                         }
                         overwrite_cofig = True
+                    
+                    # 迁移下载目录配置至列表
+                    if isinstance(self._config.get('downloaddir'), dict):
+                        downloaddir_list = []
+                        for path, attr in self._config.get('downloaddir').items():
+                            downloaddir_list.append({"save_path": path, "type": attr["type"], "category": attr["category"], "container_path": attr["path"], "label": attr["label"]})
+                        self._config['downloaddir'] = downloaddir_list
+                        overwrite_cofig = True
+
                     # 下载目录配置初始化
                     if not self._config.get('downloaddir'):
                         dl_client = self._config.get('pt', {}).get('pt_client')
@@ -254,7 +263,7 @@ class Config(object):
                             container_path = self._config.get(dl_client).get('save_containerpath')
                             if not isinstance(container_path, dict):
                                 container_path = {"movie": container_path, "tv": container_path, "anime": container_path}
-                            downloaddir = {}
+                            downloaddir = []
                             type_dict = {"movie": "电影", "tv": "电视剧", "anime": "动漫"}
                             for mtype, path in save_path.items():
                                 if not path:
@@ -264,16 +273,11 @@ class Config(object):
                                 if len(path.split('|')) > 1:
                                     save_label = path.split('|')[1]
                                 container_dir = container_path.get(mtype)
-                                if save_dir not in downloaddir.keys():
-                                    downloaddir[save_dir] = {"type": type_dict.get(mtype),
-                                                             "category": "",
-                                                             "path": container_dir,
-                                                             "label": save_label}
+                                if save_dir not in [attr["save_path"] for attr in downloaddir]:
+                                    downloaddir.append({"save_path": save_dir, "type": type_dict.get(mtype), "category": "", "container_path": container_dir, "label": save_label})
                                 else:
-                                    downloaddir[save_dir] = {"type": "",
-                                                             "category": "",
-                                                             "path": container_dir,
-                                                             "label": save_label}
+                                    existing_save_dir = next(attr for attr in downloaddir if attr['save_path'] == save_dir)
+                                    existing_save_dir["type"] = ""
                             self._config['downloaddir'] = downloaddir
                             overwrite_cofig = True
                     # 重写配置文件

--- a/web/templates/setting/downloader.html
+++ b/web/templates/setting/downloader.html
@@ -279,30 +279,30 @@
             <div class="mb-3" id="dirdiv_container">
               <label class="form-label required">目录信息 <span class="form-help" title="根据类型及二级分类自动选择下载目录，按优先级从前往后依次匹配，直到找到符合条件及空间要求的目录下载；二级分类从基础设置->二级分类策略的配置中读取，如未配置二级分类则无法配置下载目录二级分类" data-bs-toggle="tooltip">?</span></label>
               {% if Config.downloaddir %}
-              {% for Path, Dir in Config.downloaddir.items() %}
+              {% for attr in Config.downloaddir %}
               <div class="row" id="dirdiv_{{loop.index0}}">
                 <div class="col-12 col-lg-2 mb-1">
                   <select class="form-select" name="dir_type" id="dir_type_{{loop.index0}}" onchange="get_categories(this)">
-                    <option value="" {% if not Dir.type %}selected{% endif %}>全部</option>
-                    <option value="电影" {% if Dir.type == "电影" %}selected{% endif %}>电影</option>
-                    <option value="电视剧" {% if Dir.type == "电视剧" %}selected{% endif %}>电视剧</option>
-                    <option value="动漫" {% if Dir.type == "动漫" %}selected{% endif %}>动漫</option>
+                    <option value="" {% if not attr['type'] %}selected{% endif %}>全部</option>
+                    <option value="电影" {% if attr['type'] == "电影" %}selected{% endif %}>电影</option>
+                    <option value="电视剧" {% if attr['type'] == "电视剧" %}selected{% endif %}>电视剧</option>
+                    <option value="动漫" {% if attr['type'] == "动漫" %}selected{% endif %}>动漫</option>
                   </select>
                 </div>
                 <div class="col-12 col-lg-2 mb-1">
-                  <input type="hidden" id="dir_subtype_{{loop.index0}}" value="{{ Dir.category or '' }}">
+                  <input type="hidden" id="dir_subtype_{{loop.index0}}" value="{{ attr['category'] or '' }}">
                   <select class="form-select" name="dir_subtype" id="dir_subtype_value_{{loop.index0}}">
                     <option value="" selected>全部</option>
                   </select>
                 </div>
                 <div class="col-12 col-lg mb-1">
-                  <input type="text" value="{{ Path or '' }}" name="save_path" class="form-control" placeholder="下载保存目录" autocomplete="off">
+                  <input type="text" value="{{ attr['save_path'] or '' }}" name="save_path" class="form-control" placeholder="下载保存目录" autocomplete="off">
                 </div>
                 <div class="col-12 col-lg mb-1">
-                  <input type="text" value="{{ Dir.path or '' }}" name="container_path" class="form-control filetree-folders-only" placeholder="访问目录" autocomplete="off">
+                  <input type="text" value="{{ attr['container_path'] or '' }}" name="container_path" class="form-control filetree-folders-only" placeholder="访问目录" autocomplete="off">
                 </div>
                 <div class="col-12 col-lg mb-1">
-                  <input type="text" value="{{ Dir.label or '' }}" name="path_label" class="form-control" placeholder="分类标签" autocomplete="off">
+                  <input type="text" value="{{ attr['label'] or '' }}" name="path_label" class="form-control" placeholder="分类标签" autocomplete="off">
                 </div>
                 <div class="col-12 col-lg-1 mb-1 mt-2">
                   <a href="javascript:del_downloaddir('{{loop.index0}}')" class="btn-icon" title="删除下载目录">
@@ -445,12 +445,12 @@
   //保存下载目录配置
   function save_downloaddir_config(){
     $("#modal-downloaddir").modal('hide');
-    var download_dir = {};
+    var download_dir = [];
     $("[name='save_path']").each(function(){
       save_path = $(this).val();
       type = get_dir_item_value(this, 'dir_type');
       category = get_dir_item_value(this, 'dir_subtype');
-      path = get_dir_item_value(this, 'container_path');
+      container_path = get_dir_item_value(this, 'container_path');
       label = get_dir_item_value(this, 'path_label');
       debugger;
       if(download_dir[save_path]){
@@ -461,13 +461,7 @@
           category = '';
         }
       }
-
-      download_dir[save_path] = {
-        type: type,
-        category: category,
-        path: path,
-        label: label
-      };
+      download_dir.push({"save_path": save_path, "type": type, "category": category, "container_path": container_path, "label": label});
     });
     ajax_post("update_config", {downloaddir: download_dir}, function(){
       navmenu('downloader');


### PR DESCRIPTION
无损迁移downloaddir配置项至列表字典结构，支持save_path为空，靠label作为QB分类实现种子自动管理

现有嵌套字典结构

```
downloaddir:
  /media/bt/tvshow/:
    type: 电视剧
    category: ''
    path: ''
    label: tvshow
  /media/bt/movie/:
    type: 电影
    category: ''
    path: ''
    label: movie
```

迁移至列表字典结构

```
downloaddir:
- save_path: /media/bt/movie/
  type: 电影
  category: ''
  container_path: ''
  label: movie
- save_path: /media/bt/tvshow/
  type: 电视剧
  category: ''
  container_path: ''
  label: tvshow
```

related to #1516