### PR TITLE
豆瓣：修复从网页获取数据时，返回的是两个名字拼超来导致去 TMDB 搜索失败

### DIFF
--- a/app/douban.py
+++ b/app/douban.py
@@ -5,6 +5,7 @@ from time import sleep
 
 from lxml import etree
 from requests.utils import dict_from_cookiejar
+from app.utils.string_utils import StringUtils
 
 import log
 from app.helper import SqlHelper
@@ -372,9 +373,12 @@ class DouBan:
                 return None
             try:
                 html = etree.HTML(html_text)
-                ret_media['title'] = html.xpath("//span[@property='v:itemreviewed']/text()")[0]
-                if not ret_media.get('title'):
+                title = html.xpath("//span[@property='v:itemreviewed']/text()")[0]
+                if not title:
                     return None
+                if " " in title and StringUtils.is_chinese(title.split(" ")[0]):
+                    title = title.split(" ")[0]
+                ret_media['title'] = title
                 ret_media['year'] = html.xpath("//div[@id='content']//span[@class='year']/text()")[0][1:-1]
                 ret_media['intro'] = "".join(
                     [str(x).strip() for x in html.xpath("//span[@property='v:summary']/text()")])


### PR DESCRIPTION
> 17:19:54 INFO - 【DOUBAN】正在查询豆瓣详情：1760622
17:19:54 WARN - 【DOUBAN】1760622 未找到豆瓣详细信息
17:19:58 WARN - 【DOUBAN】1760622 未正确获取豆瓣详细信息，尝试使用网页获取
17:20:00 INFO - 【DOUBAN】电影：香水 Perfume: The Story of a Murderer 2006
17:18:53 WARN - 【DOUBAN】1292329 未找到豆瓣详细信息
17:18:54 WARN - 【DOUBAN】1292329 未正确获取豆瓣详细信息，尝试使用网页获取
17:18:56 INFO - 【DOUBAN】电影：牯岭街少年杀人事件 牯嶺街少年殺人事件 1991

通过网页获取详情信息时，容易得到一个简+繁或者简+英的 title，这个 title 用来搜索时就会搜不到

> 17:22:48 INFO - 【DOUBAN】牯岭街少年杀人事件 牯嶺街少年殺人事件 1991 更新到电影订阅中...
17:22:50 INFO - 【Meta】牯岭街少年杀人事件 牯嶺街少年殺人事件 以年份 1990 在TMDB中未找到电影信息!
17:22:51 INFO - 【Meta】牯岭街少年杀人事件 牯嶺街少年殺人事件 以年份 1991 在TMDB中未找到电视剧信息!

所以这里做了一个处理拿空格前的字符作为 title

考虑到纯英文也会有空格，所以判断了空格前的字符是不包含中文