### PR TITLE
fix 下载文件转移兼容下载目录为save_path子目录

### DIFF
--- a/app/downloader/client/client.py
+++ b/app/downloader/client/client.py
@@ -147,11 +147,14 @@ class IDownloadClient(metaclass=ABCMeta):
         if not path:
             return ""
         downloaddir = Config().get_config('downloaddir') or []
+        path = os.path.normpath(path)
         for attr in downloaddir:
             if not attr.get("save_path") or not attr.get("container_path"):
                 continue
-            if os.path.normpath(attr.get("save_path")) == os.path.normpath(path):
-                return attr.get("container_path")
+            save_path = os.path.normpath(attr.get("save_path"))
+            container_path = os.path.normpath(attr.get("container_path"))
+            if path.startswith(save_path):
+                return path.replace(save_path, container_path)
         return path
 
     @abstractmethod

--- a/web/action.py
+++ b/web/action.py
@@ -949,7 +949,6 @@ class WebAction:
         """
         维护同步目录
         """
-        print(data)
         sid = data.get("sid")
         source = data.get("from")
         dest = data.get("to")


### PR DESCRIPTION
原来是兼容的，后来细化目录改的不兼容了，现在改回去

例如save_path：E:\movie，文件下载目录为E:\movie\test也能正常转换目录然后转移