### PR TITLE
fix: 查询目录的子目录/文件 无法正常显示文件

### DIFF
--- a/web/apiv1.py
+++ b/web/apiv1.py
@@ -770,6 +770,9 @@ class SystemPath(ClientResource):
         try:
             d = self.parser.parse_args().get("dir") or "/"
             ft = request.form.get("filter")
+            # convert ft to bool
+            ft = True if (ft == "true" or ft == 'True' or ft == 'TRUE') else False
+
             if not os.path.isdir(d):
                 d = os.path.dirname(d)
             for f in os.listdir(d):


### PR DESCRIPTION
fix: 查询目录的子目录/文件 无法正常显示文件