### PR TITLE
修复传入的地址重定向到magnet链接时, 获取种子内容失败的问题

### DIFF
--- a/app/utils/torrent.py
+++ b/app/utils/torrent.py
@@ -71,7 +71,12 @@ class Torrent:
         if url.startswith("magnet:"):
             return url, "磁力链接"
         try:
-            req = RequestUtils(headers=ua, cookies=cookie, referer=referer).get_res(url=url)
+            req = RequestUtils(headers=ua, cookies=cookie, referer=referer).get_res(url=url, allow_redirects=False)
+            while req and req.status_code in [301, 302]:
+                url = req.headers['Location']
+                if url.startswith("magnet:"):
+                    return url, "磁力链接"
+                req = RequestUtils(headers=ua, cookies=cookie, referer=referer).get_res(url=url, allow_redirects=False)
             if req and req.status_code == 200:
                 if not req.content:
                     return None, "未下载到种子数据"


### PR DESCRIPTION
注意, 由于临时没有python开发环境, 此pr未验证正确性