### PR TITLE
优化Config单例类写法

### DIFF
--- a/config.py
+++ b/config.py
@@ -118,21 +118,18 @@ lock = Lock()
 
 class Config(object):
     _INSTANSE = None
-    _INSTANSE_FLAG = False
     _config = {}
     _config_path = None
 
     def __new__(cls, *args, **kwargs):
-        with lock:
-            if not cls._INSTANSE:
-                cls._INSTANSE = super().__new__(cls)
+        if cls._INSTANSE:
             return cls._INSTANSE
+        else:
+            with lock:
+                cls._INSTANSE = super().__new__(cls)
+                return cls._INSTANSE
 
     def __init__(self):
-        with lock:
-            if Config._INSTANSE_FLAG:
-                return
-            Config._INSTANSE_FLAG = True
         self._config_path = os.environ.get('NASTOOL_CONFIG')
         self.init_config()
 


### PR DESCRIPTION
优化了单例的写法。
锁只加在__new__即可，__init__不需要。
加锁前进行判断，不需要每次创建都必须要获得锁，当对象已经创建了以后可以直接返回不用加锁。
_INSTANSE_FLAG和_INSTANSE变量功能重复，保留了一个。
新手初次pr，请大佬多指教~