### PR TITLE
fix 下载设置下载器/历史记录、未识别记录弹出文件管理窗口

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -176,7 +176,7 @@ class DOWNLOADSETTING(Base):
     DOWNLOAD_LIMIT = Column(Integer)
     RATIO_LIMIT = Column(Integer)
     SEEDING_TIME_LIMIT = Column(Integer)
-    DOWNLOADER = Column(Integer)
+    DOWNLOADER = Column(Text)
     NOTE = Column(Text)
 
 

--- a/app/downloader/downloader.py
+++ b/app/downloader/downloader.py
@@ -98,7 +98,7 @@ class Downloader:
                 "download_limit": download_setting.DOWNLOAD_LIMIT,
                 "ratio_limit": download_setting.RATIO_LIMIT / 100,
                 "seeding_time_limit": download_setting.SEEDING_TIME_LIMIT,
-                "downloader": download_setting.NOTE}
+                "downloader": download_setting.DOWNLOADER}
 
     @property
     def client(self):

--- a/app/helper/db_helper.py
+++ b/app/helper/db_helper.py
@@ -2068,7 +2068,7 @@ class DbHelper:
                     "DOWNLOAD_LIMIT": int(float(download_limit)),
                     "RATIO_LIMIT": int(round(float(ratio_limit), 2) * 100),
                     "SEEDING_TIME_LIMIT": int(float(seeding_time_limit)),
-                    "NOTE": downloader
+                    "DOWNLOADER": downloader
                 }
             )
         else:
@@ -2082,7 +2082,7 @@ class DbHelper:
                 DOWNLOAD_LIMIT=int(float(download_limit)),
                 RATIO_LIMIT=int(round(float(ratio_limit), 2) * 100),
                 SEEDING_TIME_LIMIT=int(float(seeding_time_limit)),
-                NOTE=downloader
+                DOWNLOADER=downloader
             ))
 
     @DbPersist(_db)

--- a/db_scripts/versions/850413b9cef1_1_0_3.py
+++ b/db_scripts/versions/850413b9cef1_1_0_3.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
         batch_op.add_column(sa.Column('DEST_PATH', sa.Text))
         batch_op.add_column(sa.Column('DEST_FILENAME', sa.Text))
     with op.batch_alter_table("DOWNLOAD_SETTING") as batch_op:
-        batch_op.add_column(sa.Column('DOWNLOADER', sa.Integer))
+        batch_op.add_column(sa.Column('DOWNLOADER', sa.Text))
     # ### end Alembic commands ###
 
 

--- a/web/main.py
+++ b/web/main.py
@@ -945,6 +945,7 @@ def mediafile():
             Dir = "/"
     else:
         Dir = "/"
+    Dir = request.args.get("path") or Dir
     return render_template("rename/mediafile.html",
                            Dir=Dir)
 

--- a/web/main.py
+++ b/web/main.py
@@ -939,15 +939,15 @@ def mediafile():
     download_dirs = Downloader().get_download_visit_dirs()
     if download_dirs:
         try:
-            Dir = os.path.commonpath(download_dirs).replace("\\", "/")
+            DirD = os.path.commonpath(download_dirs).replace("\\", "/")
         except Exception as err:
             print(str(err))
-            Dir = "/"
+            DirD = "/"
     else:
-        Dir = "/"
-    Dir = request.args.get("path") or Dir
+        DirD = "/"
+    DirR = request.args.get("path")
     return render_template("rename/mediafile.html",
-                           Dir=Dir)
+                           Dir=DirR or DirD)
 
 
 # 基础设置页面

--- a/web/main.py
+++ b/web/main.py
@@ -945,7 +945,7 @@ def mediafile():
             DirD = "/"
     else:
         DirD = "/"
-    DirR = request.args.get("path")
+    DirR = request.args.get("dir")
     return render_template("rename/mediafile.html",
                            Dir=DirR or DirD)
 

--- a/web/templates/navigation.html
+++ b/web/templates/navigation.html
@@ -1276,6 +1276,15 @@
     </div>
   </div>
 </div>
+<div class="modal modal-blur fade" id="modal-mediafile" tabindex="-1" role="dialog" aria-hidden="true"
+     data-bs-backdrop="static" data-bs-keyboard="false">
+  <div class="modal-dialog modal-xl modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      <div id="frame_mediafile"></div>
+    </div>
+  </div>
+</div>
 <script src="../static/js/libs/list.min.js"></script>
 <script src="../static/js/jquery-3.3.1.min.js"></script>
 <script src="../static/js/tabler.min.js"></script>
@@ -2533,6 +2542,18 @@
       refresh_message("");
     {% endif %}
   });
+
+// 显示文件管理窗口
+  function show_mediafile_modal(dir) {
+    page = `mediafile?dir=${dir}`.replaceAll(" ", "%20");
+    CURRENT_PAGE_URI = page;
+    $("#frame_mediafile").load(page, {}, function (response, status, xhr) {
+      hide_wait_process();
+      fresh_tooltip();
+      init_filetree_element();
+    });
+    $("#modal-mediafile").modal("show");
+  }
 
 </script>
 </body>

--- a/web/templates/rename/history.html
+++ b/web/templates/rename/history.html
@@ -151,11 +151,11 @@
                     </td>
                     <td>
                       <div>
-                        <a class="text-cyan" href='javascript:jump_to_mediafile("{{ History.SOURCE_PATH.replace("\\", "/") }}")'>
+                        <a class="text-cyan" href='javascript:show_mediafile_modal("{{ History.SOURCE_PATH.replace("\\", "/") }}")'>
                         {{ History.SOURCE_FILENAME }}</a>
                       </div>
                       <div>
-                        <a class="text-orange">-> </a><a class="text-green" href='javascript:jump_to_mediafile("{{ History.DEST_PATH.replace("\\", "/") }}")'>
+                        <a class="text-orange">=> </a><a class="text-green" href='javascript:show_mediafile_modal("{{ History.DEST_PATH.replace("\\", "/") }}")'>
                         {{ History.DEST_FILENAME }}</a>
                       </div>
                     </td>
@@ -335,13 +335,6 @@
   function single_re_identification_history(logid) {
     var logids = [logid];
     re_identification(logids);
-  }
-
-  // 跳转文件管理页面
-  function jump_to_mediafile(path) {
-    console.log(path);
-    path = path.replace(/\\/g, "/");
-    navmenu("mediafile?path=" + path);{#navmenu("mediafile?path=" + path);#}
   }
 
 </script>

--- a/web/templates/rename/history.html
+++ b/web/templates/rename/history.html
@@ -151,12 +151,12 @@
                     </td>
                     <td>
                       <div>
-                        <a class="text-reset" href='javascript:jump_to_mediafile("{{ History.SOURCE_PATH.replace("\\", "/") }}")'>
+                        <a class="text-cyan" href='javascript:jump_to_mediafile("{{ History.SOURCE_PATH.replace("\\", "/") }}")'>
                         {{ History.SOURCE_FILENAME }}</a>
                       </div>
                       <div>
-                        <a class="text-reset" href='javascript:jump_to_mediafile("{{ History.DEST_PATH.replace("\\", "/") }}")'>
-                        -> {{ History.DEST_FILENAME }}</a>
+                        <a class="text-orange">-> </a><a class="text-green" href='javascript:jump_to_mediafile("{{ History.DEST_PATH.replace("\\", "/") }}")'>
+                        {{ History.DEST_FILENAME }}</a>
                       </div>
                     </td>
                     <td>{{ History.DATE }}<div class="text-muted">来自：{{ History.SOURCE }}</div></td>

--- a/web/templates/rename/history.html
+++ b/web/templates/rename/history.html
@@ -150,10 +150,16 @@
                       </div>
                     </td>
                     <td>
-                      <div>{{ History.SOURCE_FILENAME }}</div>
-                      <div class="text-muted">来自：{{ History.SOURCE }}</div>
+                      <div>
+                        <a class="text-reset" href='javascript:jump_to_mediafile("{{ History.SOURCE_PATH.replace("\\", "/") }}")'>
+                        {{ History.SOURCE_FILENAME }}</a>
+                      </div>
+                      <div>
+                        <a class="text-reset" href='javascript:jump_to_mediafile("{{ History.DEST_PATH.replace("\\", "/") }}")'>
+                        -> {{ History.DEST_FILENAME }}</a>
+                      </div>
                     </td>
-                    <td>{{ History.DATE }}</td>
+                    <td>{{ History.DATE }}<div class="text-muted">来自：{{ History.SOURCE }}</div></td>
                     <td>
                       <div class="dropdown">
                         <a href="#" class="btn-action" data-bs-toggle="dropdown" aria-expanded="false">
@@ -329,6 +335,13 @@
   function single_re_identification_history(logid) {
     var logids = [logid];
     re_identification(logids);
+  }
+
+  // 跳转文件管理页面
+  function jump_to_mediafile(path) {
+    console.log(path);
+    path = path.replace(/\\/g, "/");
+    navmenu("mediafile?path=" + path);{#navmenu("mediafile?path=" + path);#}
   }
 
 </script>

--- a/web/templates/rename/mediafile.html
+++ b/web/templates/rename/mediafile.html
@@ -18,6 +18,14 @@
               <input type="text" id="mediafile_path" value="{{ Dir }}" class="form-control" placeholder="/"
                      aria-label="Search in website">
             </div>
+            <a href="javascript:return_to_parentdir()" class="btn-action">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                  <path d="M4 18v3h16v-14l-8 -4l-8 4v3"></path>
+                  <path d="M4 14h9"></path>
+                  <path d="M10 11l3 3l-3 3"></path>
+                </svg>
+              </a>
             <div id="mediafile_tree" style="overflow-y: auto;"></div>
           </div>
         </div>
@@ -231,6 +239,14 @@
     let height = $(window).height();
     $("#mediafile_tree").css("height", (height - 240) + "px");
     $("#mediafile_file_container").css("height", (height - 225) + "px");
+  }
+
+  // 返回上级目录
+  function return_to_parentdir() {
+    let dir = $("#mediafile_path").val();
+    let parentdir = dir.substring(0, dir.lastIndexOf("/"));
+    $("#mediafile_path").val(parentdir);
+    init_mediafile_tree();
   }
 
   // 初始列表

--- a/web/templates/rename/unidentification.html
+++ b/web/templates/rename/unidentification.html
@@ -93,7 +93,7 @@
                   <tr>
                     <td><input class="form-check-input m-0 align-middle" id="check_{{ Path.id }}" type="checkbox"></td>
                     <td>
-                      {{ Path.name }}
+                      <a class="text-danger" href='javascript:show_mediafile_modal("{{ Path.name.replace("\\", "/") }}")'>{{ Path.name }}</a>
                       {% if Path.to %}
                         <div class="text-muted">
                           => {{ Path.to }}

--- a/web/templates/setting/customwords.html
+++ b/web/templates/setting/customwords.html
@@ -301,7 +301,7 @@
             <div class="mb-3">
               <label class="form-label required">偏移集数 <span class="form-help"
                   title="偏移集数支持运算，例如集数加1：EP+1；集数翻倍：2*EP；集数翻倍-1：2*EP-1" data-bs-toggle="tooltip">?</span></label>
-              <input type="text" value="" id="new_offset" class="form-control"">
+              <input type="text" value="" id="new_offset" class="form-control">
               </div>
             </div>
             <div class=" col-lg-2" id="enable_row2_div" value="0">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16237201/201721621-d7dd2649-0dcd-44a4-9181-840c292858cd.png)
![image](https://user-images.githubusercontent.com/16237201/201750320-b63224cf-6007-4992-ac44-e97088f8ccac.png)

历史记录里，点媒体信息能跳转tmdb，点源文件名，转移文件名弹出文件管理相应目录modal