### PR TITLE
fix tg消息服务正常关闭/Telegram源地址显示/自定义订阅解析种子获取文件名

### DIFF
--- a/app/message/channel/telegram.py
+++ b/app/message/channel/telegram.py
@@ -24,6 +24,7 @@ class Telegram(IMessageChannel):
     _message_proxy_event = None
     _client_config = {}
     _interactive = False
+    enabled = True
 
     def __init__(self, config, interactive=False):
         self._config = Config()
@@ -260,7 +261,7 @@ class Telegram(IMessageChannel):
             web_port = _config.get_config("app").get("web_port")
             sc_url = "https://api.telegram.org/bot%s/getUpdates?" % self._telegram_token
             ds_url = "http://127.0.0.1:%s/telegram" % web_port
-            if not self._interactive or not self._telegram_token or self._webhook:
+            if not self.enabled:
                 log.info("【Telegram】消息接收服务已停止")
                 break
 

--- a/app/message/message.py
+++ b/app/message/message.py
@@ -54,6 +54,11 @@ class Message:
 
     def init_config(self):
         # 初始化消息客户端
+        if self._active_clients:
+            for active_client in self._active_clients:
+                if active_client.get("search_type") == SearchType.TG:
+                    tg_client = active_client.get("client")
+                    tg_client.enabled = False
         self._active_clients = []
         self._client_configs = {}
         for client_config in self.dbhelper.get_message_client() or []:

--- a/app/utils/torrent.py
+++ b/app/utils/torrent.py
@@ -1,5 +1,6 @@
 import os.path
 import re
+import datetime
 from urllib.parse import quote
 from app.utils.torrentParser import TorrentParser
 from app.utils import RequestUtils
@@ -39,10 +40,13 @@ class Torrent:
                 if not req.content:
                     return None, None, [], "未下载到种子数据"
                 # 读取种子文件名
-                file_name = re.findall(r"filename=\"?(.+)\"?", req.headers.get('content-disposition'))
-                if not file_name:
-                    return None, None, [], "读取种子文件名错误"
-                file_name = str(file_name[0]).split(";")[0].strip()
+                file_name = re.findall(r"filename=\"?(.+)\"?", req.headers.get('content-disposition') or "")
+                if file_name:
+                    file_name = str(file_name[0]).split(";")[0].strip()
+                elif url.endswith(".torrent"):
+                    file_name = url.split("/")[-1]
+                else:
+                    file_name = str(datetime.datetime.now())
                 if file_name.endswith('"'):
                     file_name = file_name[:-1]
                 # 种子文件路径

--- a/web/templates/setting/basic.html
+++ b/web/templates/setting/basic.html
@@ -473,15 +473,13 @@
                                                                  title="仅接收配置的地址范围内发送的Telegram消息，多个地址段用,号分隔，配置为0.0.0.0/0,::/0则不做限制；使用Telegram WebHook且未做代理转发时推荐IPv4地址设置为：149.154.160.0/20,91.108.4.0/22，关闭Telegram WebHook时推荐IPv4地址设置为：127.0.0.1"
                                                                  data-bs-toggle="tooltip">?</span></label>
                   <input type="text"
-                         value="
-                                 {% if Config.security.telegram_webhook_allow_ip %}{{ Config.security.telegram_webhook_allow_ip.ipv4 or '' }}{% endif %}"
+                         value="{% if Config.security.telegram_webhook_allow_ip %}{{ Config.security.telegram_webhook_allow_ip.ipv4 or '' }}{% endif %}"
                          class="form-control" id="security.telegram_webhook_allow_ip.ipv4" placeholder="允许的IPv4 CIDR"
                          autocomplete="off">
                 </div>
                 <div class="mb-3">
                   <input type="text"
-                         value="
-                                 {% if Config.security.telegram_webhook_allow_ip %}{{ Config.security.telegram_webhook_allow_ip.ipv6 or '' }}{% endif %}"
+                         value="{% if Config.security.telegram_webhook_allow_ip %}{{ Config.security.telegram_webhook_allow_ip.ipv6 or '' }}{% endif %}"
                          class="form-control" id="security.telegram_webhook_allow_ip.ipv6" placeholder="允许的IPv6 CIDR"
                          autocomplete="off">
                 </div>


### PR DESCRIPTION
例如rss链接https://bangumi.moe/rss/tags/55c3024a7030f8c855f992ed+632762c72eaf6e578875f7d2+600c009432f14c00073a9f49

<enclosure url="https://bangumi.moe/download/torrent/637cf58a6b7b6500079fd4b2/[NC-Raws] 电锯人 _ Chainsaw Man - 07 (B-Global 3840x2160 HEVC AAC MKV).torrent" length="0" type="application/x-bittorrent"/>

从https://bangumi.moe/download/torrent/637cf58a6b7b6500079fd4b2/[NC-Raws] 电锯人 _ Chainsaw Man - 07 (B-Global 3840x2160 HEVC AAC MKV).torrent链接的headers里没有content-disposition取不到file_name，导致下载失败

但实际只有任意命名一下file_name，后续就能正常下载