### PR TITLE
dev 改用正则识别简体繁体和双语字幕名称

### DIFF
--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -209,14 +209,10 @@ class FileTransfer:
                             and metainfo.get_episode_string() != sub_metainfo.get_episode_string():
                         continue
                     file_ext = os.path.splitext(file_item)[-1]
-                    sub_language = os.path.basename(file_item).split(".")[-2]
-                    if sub_language and (sub_language.lower() in ["zh-cn", "cn", "zh", "zh_cn", "chs", "cht"]
-                                         or "简" in sub_language
-                                         or "中" in sub_language
-                                         or "双" in sub_language
-                                         or "chs" in sub_language.lower()
-                                         or "cht" in sub_language.lower()):
+                    if re.search("\.(((zh[-_])?(cn|chs|sg))|zh|zho|chinese|chs[-_]eng|简[体中]?|([\u4e00-\u9fa5]{0,3}[中双][\u4e00-\u9fa5]{0,2}[字文语][\u4e00-\u9fa5]{0,3}))\.", file_item, re.I):
                         new_file = os.path.splitext(new_name)[0] + ".zh-cn" + file_ext
+                    elif re.search("\.(((zh[-_])?(hk|tw|cht))|繁[体中]?|繁体中[文字]|中[文字]繁体)\.", file_item, re.I):
+                        new_file = os.path.splitext(new_name)[0] + ".zh-tw" + file_ext
                     else:
                         new_file = os.path.splitext(new_name)[0] + file_ext
                     if not os.path.exists(new_file):


### PR DESCRIPTION
抱歉, 上一次提交错到master   #2208 
听取[Shurelol](https://github.com/Shurelol)的建议改用正则识别