### PR TITLE
自定义订阅动作为下载时，若开启只管理 nastool 下载，则只有设置有 PT_TAG 的种子进行 TMDB 等检查，否则直接下载

### DIFF
--- a/config.py
+++ b/config.py
@@ -56,7 +56,7 @@ DEFAULT_TMDB_PROXY = 'https://tmdb.nastool.cn'
 # TMDB图片地址
 TMDB_IMAGE_W500_URL = 'https://image.tmdb.org/t/p/w500%s'
 TMDB_IMAGE_ORIGINAL_URL = 'https://image.tmdb.org/t/p/original/%s'
-# 添加下载时增加的标签，开始只监控NASTool添加的下载时有效
+# 添加下载时增加的标签，开启只监控NASTool添加的下载时有效
 PT_TAG = "NASTOOL"
 # 搜索种子过滤属性
 TORRENT_SEARCH_PARAMS = {


### PR DESCRIPTION
当开启只监控 NASTool 添加的下载时，下载管理中标签没有设置 PT_TAG 时，期望的行为是 nas-tools 不对其进行管理，但当前无论什么情况都会进行 TMDB 查询、媒体存在检查，导致部分种子因为检查不通过而没有下载