### PR TITLE
fix 站点下载的字幕获取正确的文件夹

### DIFF
--- a/app/downloader/downloader.py
+++ b/app/downloader/downloader.py
@@ -150,7 +150,7 @@ class Downloader:
         if not url:
             return None, "Url链接为空"
         # 默认值
-        site_info, cookie, ua, dl_files = {}, None, None, []
+        site_info, cookie, ua, dl_files_folder, dl_files = {}, None, None, "", []
         # 下载设置
         if download_setting:
             download_attr = self.get_download_setting(download_setting)
@@ -189,10 +189,10 @@ class Downloader:
                         return None, "%s 转换磁力链失败" % url
             if torrent_file:
                 # 已经下载过了种子文件，直接读取
-                content, dl_files, retmsg = Torrent().read_torrent_file(torrent_file)
+                content, dl_files_folder, dl_files, retmsg = Torrent().read_torrent_file(torrent_file)
             else:
                 # 下载种子文件，并读取信息
-                torrent_file, content, dl_files, retmsg = Torrent().get_torrent_info(
+                torrent_file, content, dl_files_folder, dl_files, retmsg = Torrent().get_torrent_info(
                     url=url,
                     cookie=cookie,
                     ua=ua,
@@ -296,10 +296,10 @@ class Downloader:
                     if visit_dir:
                         # 取种子文件的公共目录为下载目录
                         if len(dl_files) > 1:
-                            sub_dir = os.path.commonpath([os.path.join(visit_dir,
+                            sub_dir = os.path.commonpath([os.path.join(visit_dir, dl_files_folder,
                                                                        f) for f in dl_files])
                         else:
-                            sub_dir = os.path.dirname(os.path.join(visit_dir, dl_files[0]))
+                            sub_dir = os.path.dirname(os.path.join(visit_dir, dl_files_folder, dl_files[0]))
                         ThreadHelper().start_thread(Subtitle().download_subtitle_from_site,
                                                     (media_info, cookie, ua, sub_dir))
                 return ret, ""
@@ -1003,7 +1003,7 @@ class Downloader:
         if not cookie:
             return [], None
         # 保存种子文件
-        file_path, _, files, retmsg = Torrent().get_torrent_info(url=url,
+        file_path, _, _, files, retmsg = Torrent().get_torrent_info(url=url,
                                                                  cookie=cookie,
                                                                  ua=ua,
                                                                  referer=page_url if referer else None)

--- a/app/subtitle.py
+++ b/app/subtitle.py
@@ -250,7 +250,7 @@ class Subtitle:
         """
         转移字幕
         """
-        new_sub_file = "%s%s" % (os.path.splitext(media_file)[0], os.path.splitext(sub_file)[-1])
+        new_sub_file = os.path.join(os.path.splitext(media_file)[0], os.path.basename(sub_file))
         if os.path.exists(new_sub_file):
             return 1
         else:


### PR DESCRIPTION
种子内的文件资源正常会以 name 属性的名称创建一个文件夹进行保存, 站点下载的字幕在解压时没有正确的加上这个文件夹路径