### PR TITLE
调整未识别的相关逻辑

### DIFF
--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -551,10 +551,11 @@ class FileTransfer:
                     if udf_flag:
                         return success_flag, error_message
                     # 记录未识别
-                    self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
+                    is_insert_unknown = self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
                     failed_count += 1
-                    alert_count += 1
-                    if error_message not in alert_messages:
+                    if is_insert_unknown:
+                        alert_count += 1
+                    if error_message not in alert_messages and is_insert_unknown:
                         alert_messages.append(error_message)
                     # 原样转移过去
                     if unknown_dir:
@@ -645,10 +646,11 @@ class FileTransfer:
                         if udf_flag:
                             return success_flag, error_message
                         # 记录未识别
-                        self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
+                        is_insert_unknown = self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
                         failed_count += 1
-                        alert_count += 1
-                        if error_message not in alert_messages:
+                        if is_insert_unknown:
+                            alert_count += 1
+                        if error_message not in alert_messages and is_insert_unknown:
                             alert_messages.append(error_message)
                         continue
                     else:
@@ -678,10 +680,11 @@ class FileTransfer:
                             if udf_flag:
                                 return success_flag, error_message
                             # 记录未识别
-                            self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
+                            is_insert_unknown = self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
                             failed_count += 1
-                            alert_count += 1
-                            if error_message not in alert_messages:
+                            if is_insert_unknown:
+                                alert_count += 1
+                            if error_message not in alert_messages and is_insert_unknown:
                                 alert_messages.append(error_message)
                             continue
                         new_file = "%s%s" % (ret_file_path, file_ext)

--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -551,11 +551,12 @@ class FileTransfer:
                     if udf_flag:
                         return success_flag, error_message
                     # 记录未识别
-                    is_insert_unknown = self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
-                    failed_count += 1
-                    if is_insert_unknown:
+                    is_need_insert_unknown = self.dbhelper.is_need_insert_transfer_unknown(reg_path)
+                    if is_need_insert_unknown:
+                        self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
                         alert_count += 1
-                    if error_message not in alert_messages and is_insert_unknown:
+                    failed_count += 1
+                    if error_message not in alert_messages and is_need_insert_unknown:
                         alert_messages.append(error_message)
                     # 原样转移过去
                     if unknown_dir:
@@ -646,11 +647,12 @@ class FileTransfer:
                         if udf_flag:
                             return success_flag, error_message
                         # 记录未识别
-                        is_insert_unknown = self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
-                        failed_count += 1
-                        if is_insert_unknown:
+                        is_need_insert_unknown = self.dbhelper.is_need_insert_transfer_unknown(reg_path)
+                        if is_need_insert_unknown:
+                            self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
                             alert_count += 1
-                        if error_message not in alert_messages and is_insert_unknown:
+                        failed_count += 1
+                        if error_message not in alert_messages and is_need_insert_unknown:
                             alert_messages.append(error_message)
                         continue
                     else:
@@ -680,11 +682,12 @@ class FileTransfer:
                             if udf_flag:
                                 return success_flag, error_message
                             # 记录未识别
-                            is_insert_unknown = self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
-                            failed_count += 1
-                            if is_insert_unknown:
+                            is_need_insert_unknown = self.dbhelper.is_need_insert_transfer_unknown(reg_path)
+                            if is_need_insert_unknown:
+                                self.dbhelper.insert_transfer_unknown(reg_path, target_dir)
                                 alert_count += 1
-                            if error_message not in alert_messages and is_insert_unknown:
+                            failed_count += 1
+                            if error_message not in alert_messages and is_need_insert_unknown:
                                 alert_messages.append(error_message)
                             continue
                         new_file = "%s%s" % (ret_file_path, file_ext)

--- a/app/helper/db_helper.py
+++ b/app/helper/db_helper.py
@@ -403,7 +403,6 @@ class DbHelper:
                 DEST=dest,
                 STATE='N'
             ))
-            return False
 
     def is_transfer_in_blacklist(self, path):
         """

--- a/app/helper/db_helper.py
+++ b/app/helper/db_helper.py
@@ -270,7 +270,7 @@ class DbHelper:
 
     def is_transfer_history_exists_by_source_full_path(self, source_full_path):
         """
-        据源文件的全路径查询P识别转移记录
+        据源文件的全路径查询识别转移记录
         """
 
         path = os.path.dirname(source_full_path)


### PR DESCRIPTION
1. 调整未识别的相关逻辑
执行“清理转移缓存”后，进行重新同步
        a.如果源文件不存在未识别的记录，则插入未识别记录，推送入库失败的消息；
        b.如果源文件存在未处理的未识别的记录，则推送入库失败的消息；
        c.如果源文件存在已处理的未识别的记录，且不存在转移记录，则删除未识别记录并重新插入，推送入库失败的消息；（修复原有bug）
        d.如果源文件存在已处理的未识别的记录，且存在转移记录，则不推送入库失败的消息；

2. 上面 1-> c 提到的复现步骤： a. 手动识别一条未识别的记录 b. 在“历史记录”里删除刚刚的操作记录以后，就算执行“清理转移缓存”后也不能在“手动识别”或者“历史记录”里重新识别