### PR TITLE
完善Docker镜像

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
-RUN apk add --no-cache libffi-dev \
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories \
+    && apk update -f \
+    && apk add --no-cache libffi-dev \
     && apk add --no-cache $(echo $(wget --no-check-certificate -qO- https://raw.githubusercontent.com/jxxghp/nas-tools/master/package_list.txt)) \
     && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone \
@@ -7,6 +9,8 @@ RUN apk add --no-cache libffi-dev \
     && curl https://rclone.org/install.sh | bash \
     && curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o /usr/bin/mc \
     && chmod +x /usr/bin/mc \
+    && pip config set global.index-url https://pypi.douban.com/simple \
+    && npm config set registry https://registry.npmmirror.com \
     && pip install --upgrade pip setuptools wheel \
     && pip install cython \
     && pip install -r https://raw.githubusercontent.com/jxxghp/nas-tools/master/requirements.txt \

--- a/docker/Dockerfile.beta
+++ b/docker/Dockerfile.beta
@@ -1,5 +1,7 @@
 FROM alpine
-RUN apk add --no-cache libffi-dev \
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories \
+    && apk update -f \
+    && apk add --no-cache libffi-dev \
     && apk add --no-cache $(echo $(wget --no-check-certificate -qO- https://raw.githubusercontent.com/jxxghp/nas-tools/dev/package_list.txt)) \
     && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone \
@@ -7,6 +9,8 @@ RUN apk add --no-cache libffi-dev \
     && curl https://rclone.org/install.sh | bash \
     && curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o /usr/bin/mc \
     && chmod +x /usr/bin/mc \
+    && pip config set global.index-url https://pypi.douban.com/simple \
+    && npm config set registry https://registry.npmmirror.com \
     && pip install --upgrade pip setuptools wheel \
     && pip install cython \
     && pip install -r https://raw.githubusercontent.com/jxxghp/nas-tools/dev/requirements.txt \

--- a/docker/Dockerfile.lite
+++ b/docker/Dockerfile.lite
@@ -1,5 +1,7 @@
 FROM alpine
-RUN apk add --no-cache libffi-dev  \
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories \
+    && apk update -f \
+    && apk add --no-cache libffi-dev  \
     git  \
     gcc  \
     musl-dev  \
@@ -14,6 +16,8 @@ RUN apk add --no-cache libffi-dev  \
     && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone \
     && ln -sf /usr/bin/python3 /usr/bin/python \
+    && pip config set global.index-url https://pypi.douban.com/simple \
+    && npm config set registry https://registry.npmmirror.com \
     && pip install --upgrade pip setuptools wheel \
     && pip install cython \
     && pip install -r https://raw.githubusercontent.com/jxxghp/nas-tools/master/requirements.txt \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -47,6 +47,23 @@ if [ "$NASTOOL_AUTO_UPDATE" = "true" ]; then
             fi
         fi
         # 系统软件包更新
+    if [ "$NASTOOL_VERSION" = "lite" ]; then
+        hash_old=$(cat /tmp/package_list_lite.txt.sha256sum)
+        hash_new=$(sha256sum package_list_lite.txt)
+        if [ "$hash_old" != "$hash_new" ]; then
+            echo "检测到package_list_lite.txt有变化，更新软件包..."
+            apk add --no-cache libffi-dev
+            apk add --no-cache $(echo $(cat package_list_lite.txt))
+            if [ $? -ne 0 ]; then
+                echo "无法更新软件包，请更新镜像..."
+            else
+                apk del libffi-dev
+                echo "软件包安装成功..."
+                sha256sum package_list_lite.txt > /tmp/package_list_lite.txt.sha256sum
+            fi
+        fi
+    else
+    if [ "$NASTOOL_VERSION" != "lite" ]; then
         hash_old=$(cat /tmp/package_list.txt.sha256sum)
         hash_new=$(sha256sum package_list.txt)
         if [ "$hash_old" != "$hash_new" ]; then
@@ -60,7 +77,6 @@ if [ "$NASTOOL_AUTO_UPDATE" = "true" ]; then
                 echo "软件包安装成功..."
                 sha256sum package_list.txt > /tmp/package_list.txt.sha256sum
             fi
-        fi
     else
         echo "更新失败，继续使用旧的程序来启动..."
     fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,7 +18,7 @@ if [ "$NASTOOL_AUTO_UPDATE" = "true" ]; then
     git clean -dffx
     git reset --hard HEAD
     git pull
-    if [ $? -eq 0 ]; then
+        if [ $? -eq 0 ]; then
         echo "更新成功..."
         # Python依赖包更新
         hash_old=$(cat /tmp/requirements.txt.sha256sum)
@@ -47,24 +47,6 @@ if [ "$NASTOOL_AUTO_UPDATE" = "true" ]; then
             fi
         fi
         # 系统软件包更新
-    if [ "$NASTOOL_VERSION" = "lite" ]; then
-        hash_old=$(cat /tmp/package_list_lite.txt.sha256sum)
-        hash_new=$(sha256sum package_list_lite.txt)
-        if [ "$hash_old" != "$hash_new" ]; then
-            echo "检测到package_list_lite.txt有变化，更新软件包..."
-            apk add --no-cache libffi-dev
-            apk add --no-cache $(echo $(cat package_list_lite.txt))
-            if [ $? -ne 0 ]; then
-                echo "无法更新软件包，请更新镜像..."
-            else
-                apk del libffi-dev
-                echo "软件包安装成功..."
-                sha256sum package_list_lite.txt > /tmp/package_list_lite.txt.sha256sum
-            fi
-        fi
-    fi
-    else
-    if [ ! -n "$NASTOOL_VERSION" ]; then
         hash_old=$(cat /tmp/package_list.txt.sha256sum)
         hash_new=$(sha256sum package_list.txt)
         if [ "$hash_old" != "$hash_new" ]; then
@@ -82,11 +64,10 @@ if [ "$NASTOOL_AUTO_UPDATE" = "true" ]; then
     else
         echo "更新失败，继续使用旧的程序来启动..."
     fi
-fi
 else
     echo "程序自动升级已关闭，如需自动升级请在创建容器时设置环境变量：NASTOOL_AUTO_UPDATE=true"
-    fi
- echo "以PUID=${PUID}，PGID=${PGID}的身份启动程序..."
+fi
+echo "以PUID=${PUID}，PGID=${PGID}的身份启动程序..."
 mkdir -p /.local
 mkdir -p /.pm2
 if [ "$NASTOOL_VERSION" = "lite" ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -72,8 +72,12 @@ echo "以PUID=${PUID}，PGID=${PGID}的身份启动程序..."
 
 mkdir -p /.local
 mkdir -p /.pm2
-chown -R "${PUID}":"${PGID}" "${WORKDIR}" /config /usr/lib/chromium /.local /.pm2
-export PATH=$PATH:/usr/lib/chromium
+if [ "$NASTOOL_VERSION" = "lite" ]; then
+  chown -R "${PUID}":"${PGID}" "${WORKDIR}" /config /.local /.pm2
+else
+  chown -R "${PUID}":"${PGID}" "${WORKDIR}" /config /usr/lib/chromium /.local /.pm2
+  export PATH=$PATH:/usr/lib/chromium
+fi
 umask "${UMASK}"
 if ! which dumb-init; then
     apk add --no-cache dumb-init

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -96,4 +96,7 @@ else
   export PATH=$PATH:/usr/lib/chromium
 fi
 umask "${UMASK}"
+if ! which dumb-init; then
+    apk add --no-cache dumb-init
+fi
 exec su-exec "${PUID}":"${PGID}" "$(which dumb-init)" "$(which pm2-runtime)" start run.py -n NAStool --interpreter python3

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -62,6 +62,7 @@ if [ "$NASTOOL_AUTO_UPDATE" = "true" ]; then
                 sha256sum package_list_lite.txt > /tmp/package_list_lite.txt.sha256sum
             fi
         fi
+    fi
     else
     if [ "$NASTOOL_VERSION" != "lite" ]; then
         hash_old=$(cat /tmp/package_list.txt.sha256sum)
@@ -77,15 +78,15 @@ if [ "$NASTOOL_AUTO_UPDATE" = "true" ]; then
                 echo "软件包安装成功..."
                 sha256sum package_list.txt > /tmp/package_list.txt.sha256sum
             fi
+        fi
     else
         echo "更新失败，继续使用旧的程序来启动..."
     fi
+fi
 else
     echo "程序自动升级已关闭，如需自动升级请在创建容器时设置环境变量：NASTOOL_AUTO_UPDATE=true"
-fi
-
-echo "以PUID=${PUID}，PGID=${PGID}的身份启动程序..."
-
+    fi
+ echo "以PUID=${PUID}，PGID=${PGID}的身份启动程序..."
 mkdir -p /.local
 mkdir -p /.pm2
 if [ "$NASTOOL_VERSION" = "lite" ]; then
@@ -95,7 +96,4 @@ else
   export PATH=$PATH:/usr/lib/chromium
 fi
 umask "${UMASK}"
-if ! which dumb-init; then
-    apk add --no-cache dumb-init
-fi
 exec su-exec "${PUID}":"${PGID}" "$(which dumb-init)" "$(which pm2-runtime)" start run.py -n NAStool --interpreter python3

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -64,7 +64,7 @@ if [ "$NASTOOL_AUTO_UPDATE" = "true" ]; then
         fi
     fi
     else
-    if [ "$NASTOOL_VERSION" != "lite" ]; then
+    if [ ! -n "$NASTOOL_VERSION" ]; then
         hash_old=$(cat /tmp/package_list.txt.sha256sum)
         hash_new=$(sha256sum package_list.txt)
         if [ "$hash_old" != "$hash_new" ]; then

--- a/package_list_lite.txt
+++ b/package_list_lite.txt
@@ -1,7 +1,0 @@
-dumb-init
-git
-npm
-python3-dev
-py3-pip
-su-exec
-tzdata

--- a/package_list_lite.txt
+++ b/package_list_lite.txt
@@ -1,0 +1,7 @@
+dumb-init
+git
+npm
+python3-dev
+py3-pip
+su-exec
+tzdata


### PR DESCRIPTION
和另一位的PR有部分重叠。
改进处：
1.普通版和lite共用entrypoint.sh，通过环境变量NASTOOL_VERSION判断
2.替换软件源为国内镜像，方便自动更新依赖
3.添加lite版的系统依赖txt