### PR TITLE
fix 自定义订阅按状态排列/识别词ui圆点显示启用状态/订阅过滤站点（有效站点列表可以放在循环外）

### DIFF
--- a/app/helper/db_helper.py
+++ b/app/helper/db_helper.py
@@ -1855,7 +1855,7 @@ class DbHelper:
         if tid:
             return self._db.query(CONFIGUSERRSS).filter(CONFIGUSERRSS.ID == int(tid)).all()
         else:
-            return self._db.query(CONFIGUSERRSS).all()
+            return self._db.query(CONFIGUSERRSS).order_by(CONFIGUSERRSS.STATE.desc()).all()
 
     @DbPersist(_db)
     def delete_userrss_task(self, tid):

--- a/app/subscribe.py
+++ b/app/subscribe.py
@@ -309,6 +309,8 @@ class Subscribe:
         """
         ret_dict = {}
         rss_movies = self.dbhelper.get_rss_movies(rssid=rid, state=state)
+        rss_sites_valid = self.sites.get_site_names(rss=True)
+        search_sites_valid = self.indexer.get_indexer_names()
         for rss_movie in rss_movies:
             desc = rss_movie.DESC
             note = rss_movie.NOTE
@@ -340,8 +342,8 @@ class Subscribe:
                 note_info = self.__parse_rss_desc(note)
             else:
                 note_info = {}
-            rss_sites = [site for site in rss_sites if site in self.sites.get_site_names(rss=True)]
-            search_sites = [site for site in search_sites if site in self.indexer.get_indexer_names()]
+            rss_sites = [site for site in rss_sites if site in rss_sites_valid]
+            search_sites = [site for site in search_sites if site in search_sites_valid]
             ret_dict[str(rss_movie.ID)] = {
                 "id": rss_movie.ID,
                 "name": rss_movie.NAME,
@@ -370,6 +372,8 @@ class Subscribe:
     def get_subscribe_tvs(self, rid=None, state=None):
         ret_dict = {}
         rss_tvs = self.dbhelper.get_rss_tvs(rssid=rid, state=state)
+        rss_sites_valid = self.sites.get_site_names(rss=True)
+        search_sites_valid = self.indexer.get_indexer_names()
         for rss_tv in rss_tvs:
             desc = rss_tv.DESC
             note = rss_tv.NOTE
@@ -405,8 +409,8 @@ class Subscribe:
                 note_info = self.__parse_rss_desc(note)
             else:
                 note_info = {}
-            rss_sites = [site for site in rss_sites if site in self.sites.get_site_names(rss=True)]
-            search_sites = [site for site in search_sites if site in self.indexer.get_indexer_names()]
+            rss_sites = [site for site in rss_sites if site in rss_sites_valid]
+            search_sites = [site for site in search_sites if site in search_sites_valid]
             ret_dict[str(rss_tv.ID)] = {
                 "id": rss_tv.ID,
                 "name": rss_tv.NAME,

--- a/web/static/components/custom-chips/index.html
+++ b/web/static/components/custom-chips/index.html
@@ -71,7 +71,7 @@
       }
       // 所对应样式
       const color = {
-        org_string: "badge-outline text-wrap text-purple",
+        org_string: "badge-outline text-wrap text-orange",
         ignored_words: "badge-outline text-wrap text-cyan",
         replaced_words: "badge-outline text-wrap text-cyan",
         offset_words: "badge-outline text-wrap text-cyan",

--- a/web/templates/setting/customwords.html
+++ b/web/templates/setting/customwords.html
@@ -89,6 +89,7 @@
                            onclick="select_SelectALL($(this).prop('checked'), 'custom_words_{{ Group.id }}')">
                  </th>
                   {% endif %}
+                  <th class="w-1"></th>
                   <th>被替换词</th>
                   <th>替换词</th>
                   <th>偏移集数</th>
@@ -107,24 +108,20 @@
                     <input class="form-check-input m-0 align-middle" name="custom_words_{{ Group.id }}"
                            value="{{ Group.id }}_{{ Word.id }}" type="checkbox">
                   </td>
+                  <td><span class="badge bg-{% if Word.enabled == 1 %}green{% else %}red{% endif %}"></span></td>
                   <td>{{ Word.replaced }}</td>
                   <td>{{ Word.replace }}</td>
                   <td>
                     {% if Word.offset %}
-                    <span class="badge badge-outline text-cyan me-1 mb-1" style="vertical-align: middle;">{{ Word.offset
+                    <span class="badge badge-outline text-cyan mb-1" style="vertical-align: middle;">{{ Word.offset
                       }}</span>
                     {% endif %}
                   </td>
                   <td>{{ Word.front }}</td>
                   <td>{{ Word.back }}</td>
                   <td>
-                    {% if Word.enabled == 1 %}
-                    <span class="badge badge-outline text-green me-1 mb-1" style="vertical-align: middle;">启用</span>
-                    {% else %}
-                    <span class="badge badge-outline text-red me-1 mb-1" style="vertical-align: middle;">停用</span>
-                    {% endif %}
                     {% if Word.regex == 1 %}
-                    <span class="badge badge-outline text-blue me-1 mb-1" style="vertical-align: middle;">RegEx</span>
+                    <span class="badge bg-blue mb-1" style="vertical-align: middle;">RegEx</span>
                     {% endif %}
                   </td>
                   <td>


### PR DESCRIPTION
- 订阅过滤站点，有效站点列表应该不用在循环内反复取
- 自定义订阅按状态排列。启用在前，停用在后
![image](https://user-images.githubusercontent.com/16237201/211459620-fcf2ed60-28d5-4952-8abd-94ba84d3879c.png)
- 识别词ui圆点显示启用状态
![image](https://user-images.githubusercontent.com/16237201/211459684-b85a9899-8b29-4fd9-82b7-6ef0688605b3.png)

