### PR TITLE
刷流任务问题修复

### DIFF
--- a/app/downloader/client/qbittorrent.py
+++ b/app/downloader/client/qbittorrent.py
@@ -121,7 +121,7 @@ class Qbittorrent(_IDownloadClient):
         """
         if not self.qbc:
             return []
-        torrents, _ = self.get_torrents(status=["downloading"], tag=tag)
+        torrents, _ = self.get_torrents(status=["downloading", "download_pending"], tag=tag)
         return torrents
 
     def remove_torrents_tag(self, ids, tag):

--- a/app/downloader/client/transmission.py
+++ b/app/downloader/client/transmission.py
@@ -129,7 +129,7 @@ class Transmission(_IDownloadClient):
         if not self.trc:
             return []
         try:
-            torrents, _ = self.get_torrents(status=["downloading", "download_pending", "stopped"], tag=tag)
+            torrents, _ = self.get_torrents(status=["downloading", "download_pending"], tag=tag)
             return torrents
         except Exception as err:
             ExceptionUtils.exception_traceback(err)


### PR DESCRIPTION
1. 刷流任务中添加的任务数不能超过同时下载任务数
2. 正在下载的种子包括下载中和等待的种子，不能包括暂停的种子