### PR TITLE
fix: 解决RSS时选择订阅&搜索站点全选问题

### DIFF
--- a/app/searcher.py
+++ b/app/searcher.py
@@ -72,7 +72,8 @@ class Searcher:
                  搜索到的结果数量
                  下载到的结果数量，如为None则表示未开启自动下载
         """
-        if not media_info:
+
+        if not media_info or sites == []:
             return None, {}, 0, 0
         # 进度计数重置
         self.progress.start('search')

--- a/web/templates/navigation.html
+++ b/web/templates/navigation.html
@@ -1616,16 +1616,10 @@
     }
     //订阅站点
     let rss_sites = select_GetSelectedVAL("rss_sites");
-    if (rss_sites.length === RSS_SITES_LENGTH) {
-      rss_sites = [];
-    }
     //搜索站点
     let search_sites = [];
     if (!fuzzy_match) {
       search_sites = select_GetSelectedVAL("search_sites");
-      if (search_sites.length === SEARCH_SITES_LENGTH) {
-        search_sites = [];
-      }
     }
     // 储存订阅设置
     const rss_setting = {
@@ -1915,13 +1909,11 @@
   }
 
   // 刷新搜索站点列表
-  var SEARCH_SITES_LENGTH = 0;
   function refresh_searchsites_select(obj_id, item_name,aync = true) {
     ajax_post("get_indexers", {check: true, basic: true}, function (ret) {
       if (ret.code === 0) {
         let searchsites_select = $(`#${obj_id}`);
         let searchsites_select_content = "";
-        SEARCH_SITES_LENGTH = ret.indexers.length;
         if (ret.indexers.length > 0) {
           searchsites_select.parent().parent().show();
         } else {

--- a/web/templates/rss/user_rss.html
+++ b/web/templates/rss/user_rss.html
@@ -701,8 +701,8 @@
       let rss_sites = select_GetSelectedVAL('userrss_rss_rss_sites');
       let search_sites = select_GetSelectedVAL('userrss_rss_search_sites');
       userrss_detail.sites = {
-        rss_sites: (rss_sites.length === RSS_SITES_LENGTH) ? [] : rss_sites,
-        search_sites: (search_sites.length === SEARCH_SITES_LENGTH) ? [] : search_sites
+        rss_sites: rss_sites,
+        search_sites: search_sites
       }
     } else {
       return;


### PR DESCRIPTION
1. 当前认为选择站点的数量等于`RSS_SITES_LENGTH`时，即认为是全选，这会导致无法区分全选和全不选，所以删除此变量，单纯依靠站点数量判断。
2. 当前如果RSS订阅时，没有选择搜索站点，后端会默认全局搜索。正确的表现应该是，如果不选择搜索站点，则不搜索。全选才会搜索全部站点。