### PR TITLE
feat: 豆瓣想看保存历史，即使没有订阅和下载

### DIFF
--- a/app/doubansync.py
+++ b/app/doubansync.py
@@ -157,6 +157,11 @@ class DoubanSync:
                                                                           media_info=media)
                                     # 插入为已RSS状态
                                     self.dbhelper.insert_douban_media_state(media, "RSS")
+                            else:
+                                    log.info("【Douban】%s %s 更新到%s列表中..." % (
+                                        media.get_name(), media.year, media.type.value))
+                                    self.dbhelper.insert_douban_media_state(media, "NEW")
+
                     else:
                         log.info("【Douban】%s %s 已处理过" % (media.get_name(), media.year))
                 except Exception as err:

--- a/web/templates/setting/douban.html
+++ b/web/templates/setting/douban.html
@@ -159,6 +159,8 @@
                     <span class="badge bg-green">已下载</span>
                   {% elif Item.STATE == 'RSS' %}
                     <span class="badge bg-blue">已订阅</span>
+                  {% elif Item.STATE == 'NEW' %}
+                    <span class="badge bg-blue">新增</span>
                   {% else %}
                     <span class="badge bg-orange">处理中</span>
                   {% endif %}


### PR DESCRIPTION
当前情况下，豆瓣想看设置中，如果不勾选下载和订阅，将看不到豆瓣想看列表，也无法知道同步状态。

本次修改为：不勾选下载和订阅时，也会加入到想看历史，状态为`NEW`，我看 `NEW` 是本身就有的状态和判断，所以与旧代码兼容，https://github.com/jxxghp/nas-tools/blob/0c1be19111c1788b12f50ece8d381fc0a65c26fb/app/doubansync.py#L83

后续也可以考虑将这个想看列表在其他地方列表展示，不再依赖下载和订阅。

