### PR TITLE
添加 socks5h schema提示

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,8 +38,8 @@ app:
   # 【TMDB匹配模式】：normal、strict，normal模式下如使用文件名/种子名中的年份无法匹配到媒体信息，会去掉年份再匹配一次；strict模式则严格按文件中年份匹配
   # normal模式下会提升识别成功率，但也可能会导致误识别率增加；strict模式可以降低误识别率，但可能导致很多文件名/种子名中年份不正确的无法被识别（特别是剧集，需要是首播年份）
   rmt_match_mode: normal
-  # 【设置代理】，themoviedb、fanart、telegram等将使用代理访问，http和https均需配置，可以是http也可以是socks5，但需要带http或socks5前缀，两项可以配置为一样，留空则不启用
-  # 示例：'http://127.0.0.1:7890' 'socks5://127.0.0.1:8018'
+  # 【设置代理】，themoviedb、fanart、telegram等将使用代理访问，http和https均需配置，可以是http也可以是socks5、socks5h(remote DNS) ，但需要带http或socks5前缀，两项可以配置为一样，留空则不启用
+  # 示例：'http://127.0.0.1:7890' 'socks5://127.0.0.1:8018' 'socks5h://127.0.0.1:8018'
   proxies:
     http:
     https:

--- a/web/templates/setting/basic.html
+++ b/web/templates/setting/basic.html
@@ -128,7 +128,7 @@
               <div class="col-lg">
                 <div class="mb-3">
                   <label class="form-label">代理服务器 <span class="form-help"
-                                                             title="将使用代理访服务器访问themoviedb、telegram、公开bt站等境外网站及程序更新(git)，站点默认不使用代理，如需使用需在站点维护中开启；配置格式示例：127.0.0.1:7890（Http协议）、socks5://127.0.0.1:8018"
+                                                             title="将使用代理访服务器访问themoviedb、telegram、公开bt站等境外网站及程序更新(git)，站点默认不使用代理，如需使用需在站点维护中开启；配置格式示例：127.0.0.1:7890（Http协议）、socks5://127.0.0.1:8018、socks5h://127.0.0.1:8018(remote DNS)"
                                                              data-bs-toggle="tooltip">?</span></label>
                   <input type="text" value="{{ Proxy or '' }}" class="form-control" id="app.proxies"
                          placeholder="127.0.0.1:7890" autocomplete="off">


### PR DESCRIPTION
socks5 schema 使用的本地 dns 解析域名,导致像 telegram api 这样的域名很容易因为解析污染导致接口连接失败.

requests 库基于 urllib3 实现的, urllib3 支持 socks4a socks4 socks5h socks5. 官方推荐是使用 socks5h 与 socks4a .

https://urllib3.readthedocs.io/en/stable/reference/contrib/socks.html