### PR TITLE
fix: 旧版本格式不同导致无法被删除

### DIFF
--- a/app/filetransfer.py
+++ b/app/filetransfer.py
@@ -395,7 +395,7 @@ class FileTransfer:
             log.error("【Rmt】%s %s到unknown失败，错误码 %s" % (file_item, rmt_mode.value, retcode))
         return retcode
 
-    def __transfer_file(self, file_item, new_file, rmt_mode, over_flag=False):
+    def __transfer_file(self, file_item, new_file, rmt_mode, over_flag=False, old_file=None):
         """
         转移一个文件，同时处理字幕
         :param file_item: 原文件路径
@@ -407,9 +407,9 @@ class FileTransfer:
         if not over_flag and os.path.exists(new_file):
             log.warn("【Rmt】文件已存在：%s" % new_file)
             return 0
-        if over_flag and os.path.isfile(new_file):
-            log.info("【Rmt】正在删除已存在的文件：%s" % new_file)
-            os.remove(new_file)
+        if over_flag and old_file and os.path.isfile(old_file):
+            log.info("【Rmt】正在删除已存在的文件：%s" % old_file)
+            os.remove(old_file)
         log.info("【Rmt】正在转移文件：%s 到 %s" % (file_name, new_file))
         retcode = self.__transfer_command(file_item=file_item,
                                           target_file=new_file,
@@ -663,13 +663,14 @@ class FileTransfer:
                         exist_filenum = exist_filenum + 1
                         if rmt_mode != RmtMode.SOFTLINK:
                             if media.size > os.path.getsize(ret_file_path) and self._filesize_cover or udf_flag:
-                                ret_file_path = os.path.splitext(ret_file_path)[0]
+                                ret_file_path, ret_file_ext = os.path.splitext(ret_file_path)
                                 new_file = "%s%s" % (ret_file_path, file_ext)
-                                log.info("【Rmt】文件 %s 已存在，覆盖..." % new_file)
+                                old_file = "%s%s" % (ret_file_path, ret_file_ext)
+                                log.info("【Rmt】文件 %s 已存在，覆盖为 %s" % (old_file, new_file))
                                 ret = self.__transfer_file(file_item=file_item,
                                                            new_file=new_file,
                                                            rmt_mode=rmt_mode,
-                                                           over_flag=True)
+                                                           over_flag=True, old_file=old_file)
                                 if ret != 0:
                                     success_flag = False
                                     error_message = "文件转移失败，错误码 %s" % ret


### PR DESCRIPTION
RT，当洗版覆盖旧版本时，如果旧版本的媒体类型和新版本不一样，将会无法删除旧版本，新旧版本共存。比如，会同时存在：
```
Breaking Bad S01E01.mkv  // 旧
Breaking Bad S01E01.mp4 // 新
```
处理为：转移覆盖时，同时传入旧文件路径进行删除处理。