### PR TITLE
资源搜索页面，站点图标增加超链接跳转种子详情页

### DIFF
--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -184,15 +184,17 @@
                                     data-season="{{ SE_key.replace(' ', '') }}">
                                     <div class="row g-2 align-items-center">
                                       <div class="col-auto">
-                                        <span class="avatar avatar-sm rounded siteicon-{{ torrent.site|hash }}" style="overflow: hidden;">
-                                        {% if SiteDict[torrent.site|hash] %}
-                                          {% if SiteDict[torrent.site|hash].public or not SiteDict[torrent.site|hash].builtin %}
-                                          {{ torrent.site|first }}
+                                        <a  href="{{ torrent.pageurl }}" target="_blank">
+                                          <span class="avatar avatar-sm rounded siteicon-{{ torrent.site|hash }}" style="overflow: hidden;">
+                                          {% if SiteDict[torrent.site|hash] %}
+                                            {% if SiteDict[torrent.site|hash].public or not SiteDict[torrent.site|hash].builtin %}
+                                            {{ torrent.site|first }}
+                                            {% endif %}
+                                          {% else %}
+                                            {{ torrent.site|first }}
                                           {% endif %}
-                                        {% else %}
-                                          {{ torrent.site|first }}
-                                        {% endif %}
-                                        </span>
+                                          </span>
+                                        </a>
                                       </div>
                                       <div class="col">
                                         <a href='javascript:show_download_modal("{{ torrent.id }}","【{{ torrent.site }}】{{ torrent.torrent_name }}","{{ torrent.site }}")'>{{ torrent.torrent_name }}</a>


### PR DESCRIPTION
资源搜索页面，站点图标增加超链接，点击跳转种子详情页面。
因为手机端有时候想进详情页看看演员列表等等，但没有右侧三个点的dropdown，没法进入种子详情页。


或者手机端能点击其他地方进入种子详情页也可以。