### PR TITLE
fix: 单集下载遗漏

### DIFF
--- a/app/downloader/downloader.py
+++ b/app/downloader/downloader.py
@@ -639,7 +639,7 @@ class Downloader:
                         # 选中一个单季整季的或单季包括需要的所有集的
                         if item.tmdb_id == need_tmdbid \
                                 and (not item.get_episode_list()
-                                     or set(item.get_episode_list()).issuperset(set(need_episodes))) \
+                                     or set(item.get_episode_list()).intersection(set(need_episodes))) \
                                 and len(item.get_season_list()) == 1 \
                                 and item.get_season_list()[0] == need_season:
                             # 检查种子看是否有需要的集
@@ -1020,8 +1020,6 @@ class Downloader:
         :return: 集数列表、种子路径
         """
         site_info = self.sites.get_site_attr(url)
-        if not site_info.get("cookie"):
-            return [], None
         # 保存种子文件
         file_path, _, _, files, retmsg = Torrent().get_torrent_info(
             url=url,


### PR DESCRIPTION
1. 如果一个种子包含需要的部分集，使其也可以被下载
2. 对于使用第三方索引，如：Jackett， 下载种子时，是没有`site_info`的，但是它仍然是可以下载种子文件的，所以删除`cookie`的判断，和其他地方对齐。